### PR TITLE
Set dependabot group and versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      default:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
Group dependency updates to reduce noise from pull requests. Major and security updates are left grouped so that they can be given careful and, in the case of security updates,  expedited consideration.

Set the versioning strategy to "lockfile-only" because the default value, presumably "auto", would bump the required version of dependencies in the manifest(s) and in turn force these requirements onto our users.

One downside of this is that dependabot will not attempt to "widen" the versions specified in the manifest(s), which means we may forget to add support for new major versions. But as of writing the "cargo" package-ecosystem supports only "auto" and "lockfile-only".