### PR TITLE
Make the `build` verb build for only one target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ axisecp/acap-native-sdk:1.12-$(ARCH)-ubuntu22.04
 help:
 	@mkhelp print_docs $(firstword $(MAKEFILE_LIST)) help
 
-## Build <PACKAGE> for all <ARCH>
+## Build <PACKAGE> for <ARCH>
 build: target/$(ARCH)/$(PACKAGE)/_envoy
 	mkdir -p target/acap
 	cp $(patsubst %/_envoy,%/*.eap,$^) target/acap

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ axisecp/acap-native-sdk:1.12-$(ARCH)-ubuntu22.04
 help:
 	@mkhelp print_docs $(firstword $(MAKEFILE_LIST)) help
 
-## Build <PACKAGE> for all architectures
-build: target/aarch64/$(PACKAGE)/_envoy target/armv7hf/$(PACKAGE)/_envoy
+## Build <PACKAGE> for all <ARCH>
+build: target/$(ARCH)/$(PACKAGE)/_envoy
 	mkdir -p target/acap
 	cp $(patsubst %/_envoy,%/*.eap,$^) target/acap
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Once it completes there should be two `.eap` files in `target/acap`:
 ```console
 $ ls -1 target/acap
 hello_world_1_0_0_aarch64.eap
-hello_world_1_0_0_armv7hf.eap
 ```
 
 If you prefer to not use dev containers, or the implementation in your favorite IDE is buggy, the app can be built using only `docker`:


### PR DESCRIPTION
I rarely find myself wanting to build for targets other than the device that I am currently testing with, and having to wait twice as long as necessary is annoying.

I expect that CI workflows will still want to build for multiple targets, but that it should be a relatively small effort to call make twice since the developer only has to write that code once.

A side effect of this change is that CI now only builds apps other than `hello_world` for one target. This could easily be fixed by adding a couple of lines in `CI.yml` but I think this is probably desirable since I expect the compilation success to be highly correlated.