### PR TITLE
fix: Repair `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ PASS ?= pass
 # the target is up to date.
 .DELETE_ON_ERROR: ;
 
+# Don't remove intermediate files.
+.SECONDARY:
+
 # Prevent pesky default rules from creating unexpected dependency graphs.
 .SUFFIXES: ;
 


### PR DESCRIPTION
At some point, probably when resolving a merge conflict, several targets stopped working as intended. There needs to be a more structured way of running all tests, but I don't want to invest in that before I start integrating the new build tool.