### PR TITLE
Add link to acap-rs-app-template in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ _Easy and safe [ACAP] apps using [Rust]_
 > While we strive to maintain it, there's no guarantee of ongoing support, and it may become unmaintained in the future.
 > Your contributions are appreciated, and feel free to fork and continue the journey if needed.
 
+This repo is home to a mixture of developer tools, example apps, and library crates.
+To simply get started with a new app, please see [acap-rs-app-template](https://github.com/AxisCommunications/acap-rs-app-template).
+
 ## Quickstart guide
 
 Build the `hello_world` example and create `.eap` files in the `target/acap/` directory like


### PR DESCRIPTION
The intention of this link and the corresponding link in the other repo is to help potential users and contributors find the repo that is most suitable for what they want to do.