### PR TITLE
Document `python3-venv` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Ensure global prerequisites are installed:
 * Docker
 * Rust e.g. [using rustup](https://www.rust-lang.org/tools/install)
 * Python e.g. using [pyenv](https://github.com/pyenv/pyenv)
+  * When using the system python on some versions of Debian and Ubuntu, it is necessary to `apt install python3-venv`.
 
 Create, activate and populate the local development environment like
 


### PR DESCRIPTION
This will be less important once dev containers are fully adopted but we may as well document dependencies as clearly as possible.

Resolves #12