### PR TITLE
chore: Prepare logging library crate for publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "acap-logging"
+version = "0.0.0"
+dependencies = [
+ "env_logger",
+ "log",
+ "syslog",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,15 +66,6 @@ checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
  "windows-sys",
-]
-
-[[package]]
-name = "app-logging"
-version = "0.0.0"
-dependencies = [
- "env_logger",
- "log",
- "syslog",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "consume_analytics_metadata"
 version = "1.0.0"
 dependencies = [
- "app-logging",
+ "acap-logging",
  "libc",
  "log",
  "mdb",
@@ -248,7 +248,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hello_world"
 version = "1.0.0"
 dependencies = [
- "app-logging",
+ "acap-logging",
  "log",
 ]
 
@@ -353,7 +353,7 @@ dependencies = [
 name = "licensekey_handler"
 version = "1.0.0"
 dependencies = [
- "app-logging",
+ "acap-logging",
  "licensekey",
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pkg-config = "0.3.30"
 syslog = "6.1.1"
 thiserror = "1.0.57"
 
-app-logging = { path = "crates/app-logging" }
+acap-logging = { path = "crates/acap-logging" }
 licensekey = { path = "crates/licensekey" }
 licensekey-sys = { path = "crates/licensekey-sys" }
 mdb = { path = "crates/mdb" }

--- a/apps/consume_analytics_metadata/Cargo.toml
+++ b/apps/consume_analytics_metadata/Cargo.toml
@@ -7,5 +7,5 @@ edition.workspace = true
 libc = { workspace = true }
 log = { workspace = true }
 
-app-logging = { workspace = true }
+acap-logging = { workspace = true }
 mdb = { workspace = true }

--- a/apps/consume_analytics_metadata/src/main.rs
+++ b/apps/consume_analytics_metadata/src/main.rs
@@ -7,7 +7,7 @@ const TOPIC: &CStr = c"com.axis.analytics_scene_description.v0.beta";
 const SOURCE: &CStr = c"1";
 
 fn main() {
-    app_logging::init_logger();
+    acap_logging::init_logger();
 
     let connection = Connection::try_new(Some(Box::new(|e| {
         error!("Not connected because {e:?}");

--- a/apps/hello_world/Cargo.toml
+++ b/apps/hello_world/Cargo.toml
@@ -6,4 +6,4 @@ edition.workspace = true
 [dependencies]
 log = { workspace = true }
 
-app-logging = { workspace = true }
+acap-logging = { workspace = true }

--- a/apps/hello_world/src/main.rs
+++ b/apps/hello_world/src/main.rs
@@ -7,6 +7,6 @@
 use log::info;
 
 fn main() {
-    app_logging::init_logger();
+    acap_logging::init_logger();
     info!("Hello World!");
 }

--- a/apps/licensekey_handler/Cargo.toml
+++ b/apps/licensekey_handler/Cargo.toml
@@ -6,5 +6,5 @@ edition.workspace = true
 [dependencies]
 log = { workspace = true }
 
-app-logging = { workspace = true }
+acap-logging = { workspace = true }
 licensekey = { workspace = true }

--- a/apps/licensekey_handler/src/main.rs
+++ b/apps/licensekey_handler/src/main.rs
@@ -19,7 +19,7 @@ fn check_license_status(app_name: &CStr) {
 }
 
 fn main() {
-    app_logging::init_logger();
+    acap_logging::init_logger();
     let app_name = CString::new(
         std::env::current_exe()
             .unwrap()

--- a/crates/acap-logging/Cargo.toml
+++ b/crates/acap-logging/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "acap-logging"
+version = "0.0.0"
+edition.workspace = true
+description = "Logging utilities for ACAP applications"
+license = "MIT"
+readme = "README.md"
+homepage = "https://github.com/AxisCommunications/acap-rs"
+repository = "https://github.com/AxisCommunications/acap-rs"
+
+[dependencies]
+log = { workspace = true }
+env_logger = { workspace = true }
+syslog = { workspace = true }

--- a/crates/acap-logging/README.md
+++ b/crates/acap-logging/README.md
@@ -1,0 +1,3 @@
+# acap-logging
+
+_Logging utilities for ACAP applications_

--- a/crates/acap-logging/src/lib.rs
+++ b/crates/acap-logging/src/lib.rs
@@ -1,4 +1,4 @@
-//! Utilities for managing app-logging in an application.
+//! Logging utilities for ACAP applications
 
 use std::{env, io::IsTerminal};
 

--- a/crates/app-logging/Cargo.toml
+++ b/crates/app-logging/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "app-logging"
-version = "0.0.0"
-edition.workspace = true
-
-[dependencies]
-log = { workspace = true }
-env_logger = { workspace = true }
-syslog = { workspace = true }


### PR DESCRIPTION
The package is renamed to `acap-logging` to communicate that it is meant for logging in ACAP apps as opposed to apps in general.