### PR TITLE
Improve acap-logging docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "acap-logging"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "env_logger",
  "log",

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Below is the list of examples available in the repository.
 * [`licensekey_handler`](apps/licensekey_handler/src/main.rs)
 : An example that illustrates how to check the licensekey status.
 
+## Library crates
+
+| Name           | Documentation                                                   |
+|----------------|-----------------------------------------------------------------|
+| acap-logging   | [on docs.rs](https://docs.rs/acap-logging/latest/acap_logging/) |
+| licensekey     | [in source](crates/licensekey/src/lib.rs)                       |
+| licensekey-sys |                                                                 |
+| mdb            |                                                                 |
+| mdb-sys        |                                                                 |
+
 ## License
 
 [MIT](LICENSE)

--- a/apps/hello_world/src/main.rs
+++ b/apps/hello_world/src/main.rs
@@ -1,12 +1,18 @@
 //! A simple hello world application
 //!
-//! Uses some common app-logging crates to demonstrate
-//! 1. how to use them in an application, and
-//! 2. how to build and bundle them as an application.
+//! This app demonstrates:
+//! - The effect of printing to stdout and stderr.
+//! - How to configure logging and the effect of logging at various levels.
 
-use log::info;
+use log::{debug, error, info, trace, warn};
 
 fn main() {
+    eprintln!("Hello stderr!");
+    println!("Hello stdout!");
     acap_logging::init_logger();
-    info!("Hello World!");
+    trace!("Hello trace!");
+    debug!("Hello debug!");
+    info!("Hello info!");
+    warn!("Hello warn!");
+    error!("Hello error!");
 }

--- a/crates/acap-logging/Cargo.toml
+++ b/crates/acap-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acap-logging"
-version = "0.0.0"
+version = "0.0.1"
 edition.workspace = true
 description = "Logging utilities for ACAP applications"
 license = "MIT"

--- a/crates/acap-logging/README.md
+++ b/crates/acap-logging/README.md
@@ -1,3 +1,19 @@
-# acap-logging
-
 _Logging utilities for ACAP applications_
+
+The logger should be initialized as early as possible:
+
+```rust
+use log::{error, warn};
+
+fn main() {
+    error!("This will never be shown");
+    acap_logging::init_logger();
+    error!("This will usually be shown");
+}
+```
+
+Also keep in mind that:
+
+- Messages logged at the `trace` level will not be shown in the system logs on target.
+- Messages logged at the `warn` level or less severe will not be shown in terminals by default.
+- When the `tracing` crate is used in place of the `log` crate, its `log` feature must be enabled.

--- a/crates/acap-logging/README.md
+++ b/crates/acap-logging/README.md
@@ -4,10 +4,11 @@ _Logging utilities for ACAP applications_
 
 The logger is initialized as early as possible:
 
-```rust
+```no_run
 use log::{error, warn};
 
 fn main() {
+    # std::env::set_var("RUST_LOG_STYLE", "always");
     error!("This will never be shown");
     acap_logging::init_logger();
     error!("This will usually be shown");

--- a/crates/acap-logging/README.md
+++ b/crates/acap-logging/README.md
@@ -1,6 +1,8 @@
 _Logging utilities for ACAP applications_
 
-The logger should be initialized as early as possible:
+## Example
+
+The logger is initialized as early as possible:
 
 ```rust
 use log::{error, warn};
@@ -12,7 +14,7 @@ fn main() {
 }
 ```
 
-Also keep in mind that:
+## Pitfalls
 
 - Messages logged at the `trace` level will not be shown in the system logs on target.
 - Messages logged at the `warn` level or less severe will not be shown in terminals by default.

--- a/crates/acap-logging/src/lib.rs
+++ b/crates/acap-logging/src/lib.rs
@@ -14,6 +14,12 @@ fn init_syslog() {
 ///
 /// If stdout is a terminal, write to stderr.
 /// Otherwise, write to the system logger.
+///
+/// # Panics
+///
+/// This function will panic if
+/// it fails to initialize the appropriate logger or
+/// a global logger has already been initialized.
 pub fn init_logger() {
     // Using `su -pc "..."` just says the "Connection to ... closed", and
     // I have not found another way to run as the SDK user over ssh and allocate a tty, so

--- a/crates/acap-logging/src/lib.rs
+++ b/crates/acap-logging/src/lib.rs
@@ -1,5 +1,4 @@
-//! Logging utilities for ACAP applications
-
+#![doc = include_str!("../README.md")]
 use std::{env, io::IsTerminal};
 
 use log::debug;


### PR DESCRIPTION
The crate level documentation is taken from `README.md` to make it easier to ensure that crates.io, docs.rs and GitHub all show sensible documentation with minimal effort.

Also update the `hello_world` example since it would not display any output by default when run in a terminal. To increase the utility of the app a bit further without increasing the complexity it is used to also demonstrate the effect of logging at other levels and of printing.