### PR TITLE
fix: Deny lint warnings without `RUSTFLAGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ check_generated_files: $(patsubst %/,%/src/bindings.rs,$(wildcard crates/*-sys/)
 
 ## Check that the code is free of lints
 check_lint:
-	RUSTFLAGS="-Dwarnings" cargo clippy \
+	cargo clippy \
 		--all-targets \
 		--no-deps \
 		--exclude consume_analytics_metadata \
@@ -182,12 +182,12 @@ check_lint:
 		--exclude licensekey_handler \
 		--exclude mdb \
 		--exclude mdb-sys \
-		--workspace
-	RUSTFLAGS="-Dwarnings" cargo clippy \
+		--workspace -- -Dwarnings
+	cargo clippy \
 		--all-targets \
 		--no-deps \
 		--target aarch64-unknown-linux-gnu \
-		--workspace
+		--workspace -- -Dwarnings
 .PHONY: check_lint
 
 ## _


### PR DESCRIPTION
Running clippy with `RUSTFLAGS` set invalidates the cache from cargo invocations without it.

Before:
- Cold: 815,41s user 105,52s system 525% cpu 2:55,18 total
- Warm: 458,08s user  64,10s system 417% cpu 2:05,20 total

After:
- Cold: 652,06s user 81,11s system 459% cpu 2:39,48 total
- Warm:  26,31s user  1,93s system 109% cpu   25,76 total

The remaining time seems to be dominated by producing the `.eap` files; running `cargo-acap-build` takes 23s. This is in large part driven by the size of the executables because if the profile is changed to release the total size of the files that need to be packed drop from 211M to 53M and the time drops to 6s. But I suspect not all of it can be attributed to `tar` because doing that manually takes only 8s and 2s, respectively, leaving most of the time unaccounted for.