### PR TITLE
feat: Add `device-manager` bin and lib crate

### DIFF
--- a/.devhost/install-system-packages.sh
+++ b/.devhost/install-system-packages.sh
@@ -14,6 +14,7 @@ apt-get install \
   git \
   iputils-ping \
   libglib2.0-dev \
+  libssl-dev \
   pkg-config \
   python3-venv \
   sshpass

--- a/.devhost/install-venv.sh
+++ b/.devhost/install-venv.sh
@@ -40,6 +40,7 @@ npm install -g @devcontainers/cli@0.65.0
 cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target cargo-about@0.6.2
 cargo install --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/acap-ssh-utils
 cargo install --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/cargo-acap-build
+cargo install --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/device-manager
 
 rm -r /tmp/target
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 !/.devhost/
 !/crates/acap-ssh-utils
 !/crates/cargo-acap-build
+!/crates/device-manager
 !/rust-toolchain.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 *
 !/.devhost/
-!/crates/acap-ssh-utils
-!/crates/cargo-acap-build
-!/crates/device-manager
+!/Cargo.lock
+!/Cargo.toml
+!/apps/
+!/crates/
 !/rust-toolchain.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "flate2",
  "log",
@@ -130,6 +130,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -290,7 +296,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "home",
  "log",
@@ -397,6 +403,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +462,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "device-manager"
+version = "0.0.0"
+dependencies = [
+ "acap-vapix",
+ "anyhow",
+ "clap",
+ "dirs 3.0.2",
+ "env_logger",
+ "log",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,11 +516,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -503,6 +564,15 @@ checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 [[package]]
 name = "embedded_web_page"
 version = "1.0.0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_filter"
@@ -553,6 +623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +655,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -722,6 +813,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +950,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -849,6 +960,39 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1105,6 +1249,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1314,50 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -1351,25 +1556,33 @@ checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1391,6 +1604,21 @@ dependencies = [
  "syslog",
  "tokio",
  "tower-http",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1419,6 +1647,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,10 +1699,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1561,10 +1861,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1603,6 +1915,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1964,18 @@ name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "thiserror"
@@ -1728,6 +2073,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -1924,6 +2290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,6 +2338,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -2265,3 +2643,9 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ EAP_INSTALL = cd $(CURDIR)/target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)/ \
 help:
 	@mkhelp print_docs $(firstword $(MAKEFILE_LIST)) help
 
+## Reset <AXIS_DEVICE_IP> using password <AXIS_DEVICE_PASS> to a clean state suitable for development and testing.
+reinit:
+	RUST_LOG=info device-manager reinit
+
 ## Build <AXIS_PACKAGE> for <AXIS_DEVICE_ARCH>
 build: apps/$(AXIS_PACKAGE)/LICENSE
 	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE)
@@ -146,6 +150,7 @@ check_build: $(patsubst %/,%/LICENSE,$(wildcard apps/*/))
 		-- \
 		--exclude acap-ssh-utils \
 		--exclude cargo-acap-build \
+		--exclude device-manager \
 		--workspace
 
 .PHONY: check_build

--- a/crates/acap-vapix/src/apis.rs
+++ b/crates/acap-vapix/src/apis.rs
@@ -1,3 +1,4 @@
 //! A collection of bindings for individual APIs.
+pub mod parameter_management;
 
 pub mod systemready;

--- a/crates/acap-vapix/src/apis/parameter_management.rs
+++ b/crates/acap-vapix/src/apis/parameter_management.rs
@@ -1,0 +1,149 @@
+//! Bindings for the [Parameter management](https://www.axis.com/vapix-library/subjects/t10175981/section/t10036014/display).
+// TODO: Return actionable errors.
+// TODO: Implement remaining methods.
+// TODO: Proper documentation.
+// TODO: Consider encoding more knowledge about the API:
+//  - Group hierarchies.
+//  - The difference between dynamic and static groups.
+//  - The effect of wildcards.
+//  - Permissible parameter names.
+// TODO: Consider adding control over the `usergroup` argument. This is unlikely to be needed by
+//  apps but could be useful for tests.
+
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display},
+};
+
+use anyhow::{bail, Context};
+use reqwest::StatusCode;
+
+pub const PATH: &str = "axis-cgi/param.cgi";
+
+pub struct ListRequest {
+    groups: Vec<String>,
+}
+
+impl ListRequest {
+    /// Add another group to include in the list.
+    ///
+    /// If no groups are provided, all parameters will be returned when the request is executed.
+    ///
+    /// If any group is invalid, an error will be returned when the request is executed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if group contains `,`.
+    pub fn group(mut self, group: impl Display) -> Self {
+        let group = group.to_string();
+        // TODO: Consider removing asserts that don't shift errors left in a meaningful way.
+        assert!(!group.contains(','));
+        self.groups.push(group);
+        self
+    }
+
+    pub async fn execute(
+        self,
+        client: &crate::http::Client,
+    ) -> anyhow::Result<HashMap<String, String>> {
+        let mut query = vec![("action", "list")];
+        let group = self.groups.join(",");
+        if !group.is_empty() {
+            query.push(("group", &group));
+        }
+        let response = client
+            .get(PATH)?
+            .replace_with(|b| b.query(&query))
+            .send()
+            .await?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .with_context(|| format!("status code: {status}"))?;
+
+        if let Some(e) = text.trim().strip_prefix("# Error: ") {
+            bail!("{e}")
+        }
+
+        let mut untyped = HashMap::new();
+        for line in text.lines() {
+            let (k, v) = line
+                .split_once('=')
+                .with_context(|| format!("Expected at least one '=', but got {line:?}"))?;
+            if untyped.insert(k.to_string(), v.to_string()).is_some() {
+                bail!("Server sent key {k} more than once");
+            }
+        }
+        Ok(untyped)
+    }
+}
+// It would be nice to include information in these APIs about what type is returned, e.g. that
+// `root.HTTPS.port` is no less than 1, no more than 65535, and can be encoded with a `u16`.
+// It would also be nice to include information about what parameters can be expected to exist.
+// But the `listdefinitions` action may be a better place for that since that response already
+// includes that kind of metadata.
+pub fn list() -> ListRequest {
+    ListRequest { groups: Vec::new() }
+}
+
+pub struct UpdateRequest {
+    parameters: HashMap<String, String>,
+}
+
+impl UpdateRequest {
+    /// Add another parameter to be updated
+    ///
+    /// # Panics
+    ///
+    /// Panics if the same parameter is set twice or the `parameter` is one of the reserved words:
+    /// - `action`
+    /// - `usergroup`
+    pub fn set<P: Debug + Display, V: Display>(self, parameter: P, value: V) -> Self {
+        let parameter = parameter.to_string();
+        assert_ne!(parameter, "action");
+        assert_ne!(parameter, "usergroup");
+        let mut parameters = self.parameters;
+        assert_eq!(
+            parameters.insert(parameter, value.to_string()),
+            None,
+            "Expected each parameter at most once"
+        );
+        Self { parameters }
+    }
+
+    pub async fn execute(self, client: &crate::http::Client) -> anyhow::Result<()> {
+        let mut query = vec![("action", "update")];
+        for (k, v) in &self.parameters {
+            query.push((k, v));
+        }
+        let response = client
+            .get(PATH)?
+            .replace_with(|b| b.query(&query))
+            .send()
+            .await?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .with_context(|| format!("status code: {status}"))?;
+
+        if status == StatusCode::OK {
+            if text.trim() == "OK" {
+                Ok(())
+            } else {
+                bail!("Expected {status} response to state OK but got {text}");
+            }
+        } else if let Some(e) = text.trim().strip_prefix("# Error: ") {
+            bail!("{e}")
+        } else {
+            bail!("Expected {status} response to state an error, but got {text}")
+        }
+    }
+}
+
+pub fn update() -> UpdateRequest {
+    UpdateRequest {
+        parameters: HashMap::new(),
+    }
+}

--- a/crates/acap-vapix/src/http.rs
+++ b/crates/acap-vapix/src/http.rs
@@ -105,6 +105,10 @@ impl Client {
     pub fn post(&self, path: &str) -> Result<RequestBuilder, url::ParseError> {
         self.request(Method::POST, path)
     }
+
+    pub fn put(&self, path: &str) -> Result<RequestBuilder, url::ParseError> {
+        self.request(Method::PUT, path)
+    }
 }
 
 #[derive(Debug)]

--- a/crates/acap-vapix/src/lib.rs
+++ b/crates/acap-vapix/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{bail, Context};
-pub use apis::systemready;
+pub use apis::{parameter_management, systemready};
 pub use http::Client as HttpClient;
 use log::debug;
 use url::Url;

--- a/crates/device-manager/Cargo.toml
+++ b/crates/device-manager/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "device-manager"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.79"
+clap = { version = "4.5.1", features = ["derive", "env"] }
+dirs = "3.0.2"
+env_logger = "0.11.3"
+log = "0.4.22"
+regex = "1.7.2"
+reqwest = "0.12.4"
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.114"
+thiserror = "1.0.61"
+tokio = { version = "1.36.0", features = ["full"] }
+url = "2.5.0"
+
+acap-vapix = { workspace = true }

--- a/crates/device-manager/README.md
+++ b/crates/device-manager/README.md
@@ -1,0 +1,7 @@
+_Utilities for manipulating Axis devices_
+
+Currently this crate focuses on restoring devices to a known, useful state.
+It decomposes the problem into two parts:
+
+- _restore_ any device in any state to a minimal baseline configuration.
+- _initialize_ a restored device to a more useful baseline configuration.

--- a/crates/device-manager/src/initialization.rs
+++ b/crates/device-manager/src/initialization.rs
@@ -1,0 +1,165 @@
+//! Procedures for taking a restored device to some useful state.
+use std::{
+    io::{BufRead, BufReader},
+    time::Duration,
+};
+
+use acap_vapix::{parameter_management, systemready, HttpClient};
+use log::{debug, info};
+use tokio::time::sleep;
+use url::{Host, Url};
+
+use crate::vapix::{
+    axis_cgi::{self, pwdgrp},
+    config,
+};
+
+// TODO: Remove asserts that could be controlled by server
+
+fn log_stdout(mut cmd: std::process::Command) -> anyhow::Result<()> {
+    cmd.stdout(std::process::Stdio::piped());
+
+    debug!("Spawning child {cmd:#?}...");
+    let mut child = cmd.spawn()?;
+    let stdout = child.stdout.take().unwrap();
+
+    let lines = BufReader::new(stdout).lines();
+    for line in lines {
+        let line = line?;
+        if !line.is_empty() {
+            debug!("Child said {:?}.", line);
+        }
+    }
+
+    debug!("Waiting for child...");
+    let status = child.wait()?;
+    if !status.success() {
+        debug!("Child exited with status {status:?}");
+    }
+    Ok(())
+}
+
+async fn restore_root_ssh_user(client: &HttpClient, pass: &str) -> anyhow::Result<()> {
+    info!("Unsetting restrictRootAccess...");
+    axis_cgi::featureflag1::set(
+        client,
+        vec![("restrictRootAccess".to_string(), false)]
+            .into_iter()
+            .collect(),
+    )
+    .await?;
+
+    info!("Resetting root password...");
+    config::ssh1::update_user(client, "root", pass).await?;
+    Ok(())
+}
+
+async fn wait_for_param(client: &HttpClient, key: &str, value: &str) -> anyhow::Result<()> {
+    loop {
+        match parameter_management::list()
+            .group(key)
+            .execute(client)
+            .await
+        {
+            Ok(kvps) => {
+                debug!("Presumed changed");
+                assert_eq!(kvps.get(key).unwrap(), value);
+                return Ok(());
+            }
+            Err(e) => {
+                debug!("Presumed unchanged because {e}");
+                sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        }
+    }
+}
+
+pub async fn initialize(host: Host, pass: &str) -> anyhow::Result<HttpClient> {
+    let primary_user = "root";
+    let no_auth_client = HttpClient::new(Url::parse(&format!("http://{host}")).unwrap());
+
+    debug!("Assert that device can be adopted...");
+    assert!(systemready::systemready()
+        .execute(&no_auth_client)
+        .await?
+        .need_setup());
+
+    info!("Adding the primary user...");
+    pwdgrp::add(
+        &no_auth_client,
+        primary_user,
+        pass,
+        pwdgrp::Group::Root,
+        false,
+        pwdgrp::Role::AdminOperatorViewerPtz,
+    )
+    .await?;
+
+    let digest_auth_client = no_auth_client.digest_auth(primary_user, pass);
+    wait_for_param(
+        &digest_auth_client,
+        "root.Properties.API.Browser.RootPwdSetValue",
+        "yes",
+    )
+    .await?;
+
+    info!("Adding other users...");
+    pwdgrp::add(
+        &digest_auth_client,
+        "ariel",
+        pass,
+        pwdgrp::Group::Users,
+        true,
+        pwdgrp::Role::AdminOperatorViewerPtz,
+    )
+    .await?;
+    pwdgrp::add(
+        &digest_auth_client,
+        "orion",
+        pass,
+        pwdgrp::Group::Users,
+        true,
+        pwdgrp::Role::OperatorViewer,
+    )
+    .await?;
+    pwdgrp::add(
+        &digest_auth_client,
+        "vega",
+        pass,
+        pwdgrp::Group::Users,
+        true,
+        pwdgrp::Role::Viewer,
+    )
+    .await?;
+
+    info!("Enabling SSH...");
+    parameter_management::update()
+        .set("root.Network.SSH.Enabled", "yes")
+        .execute(&digest_auth_client)
+        .await?;
+
+    // TODO: Consider factoring out to `acap-ssh-utils` crate.
+    info!("Removing device from known_hosts...");
+    let mut ssh_keygen = std::process::Command::new("ssh-keygen");
+    ssh_keygen.arg("-R").arg(host.to_string());
+    log_stdout(ssh_keygen)?;
+
+    // TODO: Check firmware version, make this call only when needed, and fail failures.
+    if let Err(e) = restore_root_ssh_user(&digest_auth_client, pass).await {
+        info!("Could not restore root ssh user because {e} (this is expected on older firmware)");
+    }
+
+    // TODO: Capture stderr
+    info!("Copying SSH key...");
+    let mut sshpass = std::process::Command::new("sshpass");
+    sshpass
+        .arg(format!("-p{}", pass))
+        .arg("ssh-copy-id")
+        .args(["-o", "PubkeyAuthentication=no"])
+        .args(["-o", "StrictHostKeyChecking=no"])
+        .arg(&format!("root@{}", host));
+    log_stdout(sshpass)?;
+
+    Ok(digest_auth_client)
+}

--- a/crates/device-manager/src/lib.rs
+++ b/crates/device-manager/src/lib.rs
@@ -1,0 +1,8 @@
+#![doc = include_str!("../README.md")]
+
+mod initialization;
+mod restoration;
+mod vapix;
+
+pub use initialization::initialize;
+pub use restoration::restore;

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -1,0 +1,87 @@
+use std::{env, fs::File};
+
+use clap::{Parser, Subcommand};
+use device_manager::{initialize, restore};
+use log::debug;
+use url::Host;
+
+/// Utilities for managing individual devices.
+#[derive(Clone, Debug, Parser)]
+#[clap(verbatim_doc_comment)]
+struct Cli {
+    #[command(flatten)]
+    netloc: Netloc,
+    #[command(subcommand)]
+    command: Command,
+}
+
+impl Cli {
+    async fn exec(self) -> anyhow::Result<()> {
+        let Self {
+            netloc: Netloc { host, user, pass },
+            command,
+        } = self;
+        match command {
+            Command::Reinit => {
+                restore(&host, &user, &pass).await?;
+                initialize(host, &pass).await?;
+                if user != "root" {
+                    println!("Remember that the primary user has changed from {user} to root")
+                }
+            }
+            Command::Restore => {
+                restore(&host, &user, &pass).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Parser)]
+struct Netloc {
+    /// Hostname or IP address of the device.
+    #[arg(long, value_parser = url::Host::parse, env = "AXIS_DEVICE_IP")]
+    host: Host,
+    /// The username to use for the ssh connection.
+    #[clap(short, long, env = "AXIS_DEVICE_USER")]
+    user: String,
+    /// The password to use for the ssh connection.
+    #[clap(short, long, env = "AXIS_DEVICE_PASS")]
+    pass: String,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum Command {
+    /// Restore device to a clean state.
+    Restore,
+    /// Restore and initialize device to a known, useful state.
+    Reinit,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let log_file = if env::var_os("RUST_LOG").is_none() {
+        let dir = dirs::runtime_dir().unwrap_or(env::temp_dir());
+        let path = dir.join("cargo-acap-sdk.log");
+        let target = env_logger::Target::Pipe(Box::new(File::create(&path)?));
+        let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
+        builder.target(target).filter_level(log::LevelFilter::Debug);
+        builder.init();
+        Some(path)
+    } else {
+        env_logger::init();
+        None
+    };
+    debug!("Logging initialized");
+
+    match Cli::parse().exec().await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if let Some(log_file) = log_file {
+                Err(e.context(format!("A detailed log has been saved to {log_file:?}")))
+            } else {
+                Err(e)
+            }
+        }
+    }
+}

--- a/crates/device-manager/src/restoration.rs
+++ b/crates/device-manager/src/restoration.rs
@@ -1,0 +1,168 @@
+//! A procedure for taking a device in any state to a known baseline state.
+use std::time::Duration;
+
+use acap_vapix::{systemready, HttpClient};
+use anyhow::bail;
+use log::{debug, info};
+use tokio::time::sleep;
+use url::{Host, Url};
+
+use crate::vapix::axis_cgi::firmwaremanagement1;
+
+enum RestartDetector<'a> {
+    StateTransition(StateTransitionRestartDetector<'a>),
+    Uptime(UptimeRestartDetector<'a>),
+}
+
+impl<'a> RestartDetector<'a> {
+    pub async fn try_new(client: &'a HttpClient) -> anyhow::Result<Self> {
+        Ok(
+            match systemready::systemready().execute(client).await?.uptime() {
+                Some(uptime) => Self::Uptime(UptimeRestartDetector::new(client, uptime)),
+                None => Self::StateTransition(StateTransitionRestartDetector::new(client)),
+            },
+        )
+    }
+
+    pub async fn wait(self) -> anyhow::Result<()> {
+        match self {
+            Self::StateTransition(g) => g.wait().await,
+            Self::Uptime(g) => g.wait().await,
+        }
+    }
+}
+
+enum RestartDetectorState {
+    Ready,
+    NotReady,
+}
+struct StateTransitionRestartDetector<'a> {
+    client: &'a HttpClient,
+    prev_state: RestartDetectorState,
+}
+impl<'a> StateTransitionRestartDetector<'a> {
+    fn new(client: &'a HttpClient) -> Self {
+        Self {
+            client,
+            prev_state: RestartDetectorState::Ready,
+        }
+    }
+
+    async fn wait(mut self) -> anyhow::Result<()> {
+        use RestartDetectorState::*;
+        loop {
+            let curr_state = match systemready::systemready().execute(self.client).await {
+                Ok(data) => {
+                    if data.system_ready() {
+                        Ready
+                    } else {
+                        NotReady
+                    }
+                }
+                Err(e) => {
+                    debug!("Presumed not ready  because {e}");
+                    NotReady
+                }
+            };
+            self.prev_state = match (self.prev_state, curr_state) {
+                (Ready, Ready) => {
+                    debug!("Device is still ready");
+                    Ready
+                }
+                (Ready, NotReady) => {
+                    debug!("Device became not ready");
+                    NotReady
+                }
+                (NotReady, NotReady) => {
+                    debug!("Device is still not ready");
+                    NotReady
+                }
+                (NotReady, Ready) => {
+                    debug!("Device became ready again");
+                    return Ok(());
+                }
+            };
+            sleep(Duration::from_secs(1)).await;
+        }
+    }
+}
+struct UptimeRestartDetector<'a> {
+    client: &'a HttpClient,
+    // TODO: Consider using boot id when available
+    uptime: Duration,
+}
+
+impl<'a> UptimeRestartDetector<'a> {
+    fn new(client: &'a HttpClient, uptime: Duration) -> Self {
+        Self { client, uptime }
+    }
+
+    async fn wait(mut self) -> anyhow::Result<()> {
+        loop {
+            match systemready::systemready().execute(self.client).await {
+                Ok(data) => {
+                    let uptime = data.uptime().unwrap();
+                    if uptime < self.uptime {
+                        debug!(
+                            "Presumed restarted because uptime decreased from {:?} to {:?}",
+                            self.uptime, uptime
+                        );
+                        return Ok(());
+                    } else {
+                        debug!(
+                            "Presumed online still because uptime increased from {:?} to {:?}",
+                            self.uptime, uptime
+                        );
+                        self.uptime = uptime;
+                        sleep(Duration::from_secs(1)).await;
+                    }
+                }
+                Err(e) => {
+                    debug!("Presumed offline because {e}");
+                    sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+}
+
+pub async fn restore(host: &Host, user: &str, pass: &str) -> anyhow::Result<()> {
+    info!("Restoring device...");
+    let mut client = HttpClient::new(Url::parse(&format!("http://{host}")).unwrap());
+    debug!("Checking if factory default is needed...");
+    if systemready::systemready()
+        .execute(&client)
+        .await?
+        .need_setup()
+    {
+        info!("Device is already in default state...");
+        return Ok(());
+    }
+
+    for use_digest in [true, false] {
+        if use_digest {
+            info!("Trying to factory default using digest");
+            client = client.digest_auth(user, pass);
+        } else {
+            info!("Trying to factory default using basic");
+            client = client.basic_auth(user, pass);
+        }
+
+        let restart_guard = RestartDetector::try_new(&client).await?;
+        match firmwaremanagement1::factory_default(
+            &client,
+            firmwaremanagement1::FactoryDefaultMode::Soft,
+        )
+        .await
+        {
+            Ok(()) => {
+                restart_guard.wait().await?;
+                return Ok(());
+            }
+            Err(e) => {
+                debug!("Could not factory default using because {e}");
+            }
+        }
+    }
+    bail!("Could not factory default camera")
+}

--- a/crates/device-manager/src/vapix.rs
+++ b/crates/device-manager/src/vapix.rs
@@ -1,0 +1,6 @@
+// TODO: Move bindings into `acap-vapix` or at least reuse AJR.
+mod ajr;
+
+mod ajr_http;
+pub mod axis_cgi;
+pub mod config;

--- a/crates/device-manager/src/vapix/ajr.rs
+++ b/crates/device-manager/src/vapix/ajr.rs
@@ -1,0 +1,322 @@
+/// Reusable functionality clients and servers that use some dialect of Axis JSON RPC (AJR).
+// TODO: Consider handcrafting [de]serialization.
+// This should allow us to:
+// * simplify types
+// * provide better error when deserialization fails
+// * fail or warn when messages don't strictly conform to the standard
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestEnvelope<P> {
+    api_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+    #[serde(flatten)]
+    params: P,
+}
+
+impl<P> RequestEnvelope<P> {
+    pub(crate) fn new(api_version: impl ToString, context: Option<String>, params: P) -> Self {
+        Self {
+            api_version: api_version.to_string(),
+            context: context.map(|c| c.to_string()),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResponseEnvelope<T> {
+    api_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+    #[serde(flatten)]
+    result: EnvelopeResult<T>,
+}
+
+impl<T> ResponseEnvelope<T> {
+    #[cfg(test)]
+    pub fn new_data(api_version: impl ToString, context: Option<String>, data: T) -> Self {
+        Self {
+            api_version: api_version.to_string(),
+            context: context.map(|c| c.to_string()),
+            result: EnvelopeResult::Data(data),
+        }
+    }
+    #[cfg(test)]
+    fn new_error(api_version: impl ToString, context: Option<String>, error: Error) -> Self {
+        Self {
+            api_version: api_version.to_string(),
+            context: context.map(|c| c.to_string()),
+            result: EnvelopeResult::Error(TaggedError {
+                method: None,
+                error,
+            }),
+        }
+    }
+    pub fn data(self) -> Result<T, Error> {
+        match self.result {
+            EnvelopeResult::Error(TaggedError { error, .. }) => Err(error),
+            EnvelopeResult::Data(d) => Ok(d),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+enum EnvelopeResult<T> {
+    // If a response contains both a valid data and error, it will be silently deserialized to one.
+    // List error first, so that this variant is preferred.
+    Error(TaggedError),
+    Data(T),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct TaggedError {
+    // We need to be able to capture the method but since all methods return the same error type
+    // there's no enum tag that can capture this for us.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    method: Option<String>,
+    error: Error,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, thiserror::Error)]
+pub struct Error {
+    code: u32,
+    message: String,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Self { code, message } = self;
+        write!(f, "{message} ({code})")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Value};
+
+    use super::*;
+
+    // Pros of wrapping requests in enum:
+    // * Serde can be used to communicate the method instead of a separate trait.
+    //   Since most APIs support only HTTP the method could also be passed as an argument,
+    //   but either way this is a bit of a nuisance.
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", tag = "method", content = "params")]
+    enum Params {
+        Empty,
+        EmptyNamed {},
+        // `EmptyUnnamed()`  would be serialized as a list, so don't do it
+        Named { foo: u32 },
+        Unnamed(Bar),
+    }
+
+    #[derive(Clone, Eq, Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", tag = "method", content = "data")]
+    enum Data {
+        Named { foo: u32 },
+        Unnamed(Bar),
+        Empty,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Bar {
+        bar: u32,
+    }
+
+    #[test]
+    fn can_serialize_and_deserialize_request_examples() {
+        let before = Params::Empty;
+        let request = RequestEnvelope::new(1, None, before.clone());
+        let text = serde_json::to_string(&request).unwrap();
+        let after = serde_json::from_str::<RequestEnvelope<Params>>(&text)
+            .unwrap()
+            .params;
+        assert_eq!(text, r#"{"apiVersion":"1","method":"empty"}"#);
+        assert_eq!(before, after);
+
+        let before = Params::EmptyNamed {};
+        let request = RequestEnvelope::new(1, None, before.clone());
+        let text = serde_json::to_string(&request).unwrap();
+        let after = serde_json::from_str::<RequestEnvelope<Params>>(&text)
+            .unwrap()
+            .params;
+        assert_eq!(
+            text,
+            r#"{"apiVersion":"1","method":"emptyNamed","params":{}}"#
+        );
+        assert_eq!(before, after);
+
+        let before = Params::Named { foo: 123 };
+        let request = RequestEnvelope::new(1, None, before.clone());
+        let text = serde_json::to_string(&request).unwrap();
+        let after = serde_json::from_str::<RequestEnvelope<Params>>(&text)
+            .unwrap()
+            .params;
+        assert_eq!(
+            text,
+            r#"{"apiVersion":"1","method":"named","params":{"foo":123}}"#
+        );
+        assert_eq!(before, after);
+
+        let before = Params::Unnamed(Bar { bar: 234 });
+        let deserialized = RequestEnvelope::new(1, None, before.clone());
+        let serialized = serde_json::to_string(&deserialized).unwrap();
+        let after = serde_json::from_str::<RequestEnvelope<Params>>(&serialized)
+            .unwrap()
+            .params;
+        assert_eq!(
+            serialized,
+            r#"{"apiVersion":"1","method":"unnamed","params":{"bar":234}}"#
+        );
+        assert_eq!(before, after);
+    }
+    #[test]
+    fn can_serialize_and_deserialize_data_response_examples() {
+        // TODO: Consider asserting that the serialized representation is as expected
+        for before in [
+            Data::Named { foo: 123 },
+            Data::Unnamed(Bar { bar: 234 }),
+            Data::Empty,
+        ] {
+            let deserialized = ResponseEnvelope::new_data(1, None, before.clone());
+            let serialized = serde_json::to_string(&deserialized).unwrap();
+            let after = serde_json::from_str::<ResponseEnvelope<Data>>(&serialized)
+                .unwrap()
+                .data()
+                .unwrap();
+            assert_eq!(before, after);
+        }
+    }
+    #[test]
+    fn can_serialize_and_deserialize_error_response() {
+        // TODO: Consider asserting that the serialized representation is as expected
+        let before = Error {
+            code: 123,
+            message: "Oops".to_string(),
+        };
+        let text = serde_json::to_string(&ResponseEnvelope::<Data>::new_error(
+            1,
+            None,
+            before.clone(),
+        ))
+        .unwrap();
+        println!("{text}");
+        let after = serde_json::from_str::<ResponseEnvelope<Data>>(&text)
+            .unwrap()
+            .data()
+            .err()
+            .unwrap();
+        assert_eq!(before, after)
+    }
+    #[test]
+    fn can_deserialize_and_serialize_good_responses() {
+        // TODO: Consider asserting that the deserialized representation is as expected
+        let texts = vec![
+            r#"{"apiVersion":"0","error":{"code":1000,"message":"Oops"}}"#,
+            r#"{"apiVersion":"0","method":"named","error":{"code":1000,"message":"Oops"}}"#,
+            r#"{"apiVersion":"0","method":"named","data":{"foo":1}}"#,
+            r#"{"apiVersion":"0","method":"unnamed","data":{"bar":1}}"#,
+            r#"{"apiVersion":"0","method":"empty"}"#,
+        ];
+        for expected in texts {
+            let deserialized: ResponseEnvelope<Data> = serde_json::from_str(expected).unwrap();
+            println!("{deserialized:?}");
+            let actual = serde_json::to_string(&deserialized).unwrap();
+            assert_eq!(actual, expected);
+        }
+    }
+    #[test]
+    fn cannot_deserialize_bad_responses() {
+        let texts = vec![
+            // Wrong key in data
+            r#"{"apiVersion":"0","method":"named","data":{"bar":2}}"#,
+            // Missing data (content)
+            r#"{"apiVersion":"0","method":"named"}"#,
+            // Missing data (method)
+            r#"{"apiVersion":"0","data":{"foo":1}}"#,
+            // Neither data nor error
+            r#"{"apiVersion":"0"}"#,
+        ];
+        for expected in texts {
+            assert!(serde_json::from_str::<ResponseEnvelope<Data>>(expected).is_err());
+        }
+    }
+
+    #[test]
+    fn can_deserialize_weird_responses() {
+        // TODO: Consider asserting that the deserialized representation is as expected
+
+        // Extra key in data
+        let before = r#"{"apiVersion":"0","method":"named","data":{"foo":1,"bar":2}}"#;
+        let deserialized: ResponseEnvelope<Data> = serde_json::from_str(before).unwrap();
+        let after = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(
+            after,
+            r#"{"apiVersion":"0","method":"named","data":{"foo":1}}"#
+        );
+
+        // Both data and error
+        let before = r#"{"apiVersion":"0","method":"named","data":{"foo":1},"error":{"code":1000,"message":"Oops"}}"#;
+        let deserialized: ResponseEnvelope<Data> = serde_json::from_str(before).unwrap();
+        let after = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(
+            after,
+            r#"{"apiVersion":"0","method":"named","error":{"code":1000,"message":"Oops"}}"#
+        );
+    }
+
+    #[test]
+    fn can_deserialize_arbitrary_data() {
+        let serialized =
+            r#"{"apiVersion":"0","method":"named","data":{"foo":1,"bar":{"foobar":2}}}"#;
+        let deserialized: ResponseEnvelope<Value> = serde_json::from_str(serialized).unwrap();
+        let _actual = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(
+            deserialized.data().unwrap(),
+            json!({"data":{"foo":1,"bar":{"foobar":2}},"method":"named"})
+        );
+        // We don't expect that serializing will give the original text back because `Value`
+        // does not retain order.
+    }
+
+    #[test]
+    fn supports_untagged_response() {
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Foo {
+            foo: u32,
+        }
+
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+        #[serde(rename_all = "camelCase", untagged)]
+        enum UntaggedData {
+            Named { data: Foo },
+        }
+
+        println!(
+            "{}",
+            serde_json::to_string(&ResponseEnvelope::new_data(
+                0,
+                None,
+                UntaggedData::Named {
+                    data: Foo { foo: 1 }
+                }
+            ))
+            .unwrap()
+        );
+
+        let before = r#"{"apiVersion":"0","data":{"foo":1}}"#;
+        let deserialized: ResponseEnvelope<UntaggedData> = serde_json::from_str(before).unwrap();
+        let after = serde_json::to_string(&deserialized).unwrap();
+        assert_eq!(before, after);
+    }
+}

--- a/crates/device-manager/src/vapix/ajr_http.rs
+++ b/crates/device-manager/src/vapix/ajr_http.rs
@@ -1,0 +1,88 @@
+use std::fmt::Debug;
+
+use acap_vapix::HttpClient;
+use anyhow::Context;
+use log::debug;
+use serde::{Deserialize, Serialize};
+
+use crate::vapix::{
+    ajr,
+    ajr::{RequestEnvelope, ResponseEnvelope},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Transport(reqwest::Error),
+    // A valid HTTP response is received but we cannot parse an AJR response because
+    // * not valid json
+    // * does not deserialize into the typed ResponseEnvelope
+    // * the data is the wrong variant
+    #[error(transparent)]
+    Protocol(anyhow::Error),
+    #[error(transparent)]
+    Application(ajr::Error),
+    // TODO: Remove
+    #[error(transparent)]
+    Other(anyhow::Error),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(value: reqwest::Error) -> Self {
+        Self::Transport(value)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Protocol(value.into())
+    }
+}
+impl From<ajr::Error> for Error {
+    fn from(value: ajr::Error) -> Self {
+        Self::Application(value)
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Other(value)
+    }
+}
+
+/// Use `client` to execute RPC specified by `path`, `api_version`, `method`, and `params`
+pub async fn exec<P, D>(
+    client: &HttpClient,
+    path: &str,
+    // Strictly this should be an int for the major because APIs server only one minor at a time.
+    // But some APIs require a minor version too.
+    api_version: impl ToString,
+    // Strictly this should always be None because it is redundant for HTTP, which is already
+    // request-response, making the overhead unjustified.
+    // But some APIs require it anyway.
+    context: Option<String>,
+    params: P,
+) -> Result<D, Error>
+where
+    P: Serialize + Debug,
+    D: for<'a> Deserialize<'a>,
+{
+    let request_envelope = RequestEnvelope::new(api_version, context, params);
+    debug!("Building from {request_envelope:#?}");
+    debug!(
+        "Text: {}",
+        serde_json::to_string(&request_envelope).unwrap()
+    );
+    let builder = client
+        .post(path)
+        .unwrap()
+        .replace_with(|b| b.json(&request_envelope));
+    debug!("Sending");
+    let http = builder.send().await?;
+    debug!("Extracting");
+    let status = http.status();
+    let text = http.text().await?;
+    debug!("Response text: {text}");
+    let response_envelope = serde_json::from_str::<ResponseEnvelope<D>>(&text).context(status)?;
+    Ok(response_envelope.data()?)
+}

--- a/crates/device-manager/src/vapix/axis_cgi.rs
+++ b/crates/device-manager/src/vapix/axis_cgi.rs
@@ -1,0 +1,4 @@
+pub mod featureflag1;
+pub mod firmwaremanagement1;
+
+pub mod pwdgrp;

--- a/crates/device-manager/src/vapix/axis_cgi/featureflag1.rs
+++ b/crates/device-manager/src/vapix/axis_cgi/featureflag1.rs
@@ -1,0 +1,91 @@
+use std::collections::HashMap;
+
+use acap_vapix::HttpClient;
+use anyhow::bail;
+use serde::{Deserialize, Serialize};
+
+use crate::vapix::ajr_http;
+
+const PATH: &str = "axis-cgi/featureflag.cgi";
+const VERSION: &str = "1.0";
+// TODO: Make builder the primary interface
+// To enable a consistent API we probably want the user to first create a builder, then call it with
+// a client.
+pub async fn set(client: &HttpClient, flag_values: HashMap<String, bool>) -> anyhow::Result<()> {
+    let data = ajr_http::exec(
+        client,
+        PATH,
+        VERSION,
+        None,
+        Params::Set(SetParams { flag_values }),
+    )
+    .await?;
+    let Data::Set { result } = data else {
+        bail!("Expected Data::Set but got {data:?}");
+    };
+    if result != "Success" {
+        bail!(r#"Expected result "Success" but got {result}"#);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "method", content = "params")]
+enum Params {
+    ListAll,
+    Set(SetParams),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetParams {
+    flag_values: HashMap<String, bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "method", content = "data")]
+enum Data {
+    Set { result: String },
+    ListAll { flags: Vec<Flag> },
+}
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Flag {
+    pub name: String,
+    pub value: bool,
+    description: String,
+    default_value: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vapix::ajr::{RequestEnvelope, ResponseEnvelope};
+
+    macro_rules! to_string_map {
+    ($($k:expr => $v:expr),* $(,)?) => {{
+        std::collections::HashMap::from([$(($k.to_string(), $v),)*])
+    }};
+}
+
+    #[test]
+    fn can_serialize_request() {
+        let req = RequestEnvelope::new(
+            VERSION,
+            None,
+            Params::Set(SetParams {
+                flag_values: to_string_map! {"restrictRootAccess" => false},
+            }),
+        );
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            r#"{"apiVersion":"1.0","method":"set","params":{"flagValues":{"restrictRootAccess":false}}}"#
+        )
+    }
+
+    #[test]
+    fn can_deserialize_response() {
+        let res = r#"{"apiVersion":"1.0","method":"set","data":{"result":"Success"}}"#;
+        let _: ResponseEnvelope<Data> = serde_json::from_str(res).unwrap();
+    }
+}

--- a/crates/device-manager/src/vapix/axis_cgi/firmwaremanagement1.rs
+++ b/crates/device-manager/src/vapix/axis_cgi/firmwaremanagement1.rs
@@ -1,0 +1,88 @@
+use anyhow::bail;
+use serde::{Deserialize, Serialize};
+
+use crate::vapix::ajr_http;
+
+const PATH: &str = "axis-cgi/firmwaremanagement.cgi";
+const VERSION: &str = "1.0";
+pub async fn factory_default(
+    client: &acap_vapix::HttpClient,
+    mode: FactoryDefaultMode,
+) -> anyhow::Result<()> {
+    let data = ajr_http::exec(
+        client,
+        PATH,
+        VERSION,
+        None,
+        Params::FactoryDefault(FactoryDefaultParams {
+            factory_default_mode: mode,
+        }),
+    )
+    .await?;
+    let Data::FactoryDefault {} = data else {
+        bail!("Expected Data::FactoryDefault but got {data:?}")
+    };
+    Ok(())
+}
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DataResponse {}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "method", content = "params")]
+enum Params {
+    FactoryDefault(FactoryDefaultParams),
+    Status,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FactoryDefaultParams {
+    factory_default_mode: FactoryDefaultMode,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FactoryDefaultMode {
+    Soft,
+    Hard,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "method", content = "data")]
+enum Data {
+    FactoryDefault {},
+    Status(StatusData),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusData {
+    /// Current firmware version.
+    active_firmware_version: String,
+    /// Current firmware part number.
+    active_firmware_part: String,
+    /// Inactive firmware version. This is only present if an inactive firmware exists, which will
+    /// be reported as “UNKNOWN” if the inactive firmware doesn't support the automatic firmware
+    /// rollback parameters.
+    inactive_firmware_version: Option<String>,
+    /// True if current firmware is committed.
+    /// False if the current firmware is uncommitted and will rollback on reboot.
+    ///
+    /// This is only present if an inactive firmware exists.
+    is_commited: Option<bool>,
+    /// Pending auto commit.
+    ///
+    /// "started" The current firmware will be automatically committed once the device has finished
+    /// booting, see Upgrade.
+    ///
+    /// This is only present if the active firmware is uncommitted and an automatic commit is
+    /// pending.
+    pending_commit: Option<String>,
+    /// Number of seconds left to automatic rollback.
+    ///
+    /// This is only present if active firmware is uncommitted and an automatic rollback is pending.
+    time_to_rollback: Option<u32>,
+    /// The date and time when the Axis product was upgraded.
+    ///
+    /// This is only present if an inactive firmware exists.
+    last_upgrade_at: Option<String>,
+}

--- a/crates/device-manager/src/vapix/axis_cgi/pwdgrp.rs
+++ b/crates/device-manager/src/vapix/axis_cgi/pwdgrp.rs
@@ -1,0 +1,101 @@
+use std::fmt::{Display, Formatter};
+
+use anyhow::{bail, Context};
+use regex::RegexBuilder;
+use reqwest::StatusCode;
+
+macro_rules! map {
+    ($($k:expr => $v:expr),* $(,)?) => {{
+        std::collections::HashMap::from([$(($k, $v),)*])
+    }};
+}
+
+fn extract_body(html: &str) -> Option<&str> {
+    // Unwrapping is OK because the regex is hardcoded.
+    let re = RegexBuilder::new(r"<body.*?>(.*?)</body>")
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap();
+    // Unwrapping is OK because we know that the regex has a capture group.
+    Some(re.captures(html)?.get(1).unwrap().as_str())
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Role {
+    Viewer,
+    OperatorViewer,
+    AdminOperatorViewerPtz,
+}
+impl Display for Role {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Role::Viewer => write!(f, "viewer"),
+            Role::OperatorViewer => write!(f, "operator:viewer"),
+            Role::AdminOperatorViewerPtz => write!(f, "admin:operator:viewer:ptz"),
+        }
+    }
+}
+pub enum Group {
+    Root,
+    Users,
+}
+
+impl Display for Group {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Group::Root => write!(f, "root"),
+            Group::Users => write!(f, "users"),
+        }
+    }
+}
+
+const PATH: &str = "axis-cgi/pwdgrp.cgi";
+// TODO: Improve generality
+pub async fn add(
+    client: &acap_vapix::HttpClient,
+    username: &str,
+    password: &str,
+    group: Group,
+    strict: bool,
+    role: Role,
+) -> anyhow::Result<()> {
+    let role = role.to_string();
+    let group = group.to_string();
+    let mut query = map!(
+        "action" => "add",
+        "user" => username,
+        "pwd" => password,
+        "grp" => &group,
+        "sgrp" => &role,
+    );
+    if strict {
+        query.insert("strict_pwd", "1");
+    }
+    let resp = client
+        .get(PATH)
+        .unwrap()
+        .replace_with(|b| b.query(&query))
+        .send()
+        .await?
+        .error_for_status()?;
+    let status = resp.status();
+    let text = resp.text().await?;
+    let body = extract_body(&text).context(text.clone())?;
+    if (status, body.trim()) != (StatusCode::OK, &format!("Created account {username}.")) {
+        bail!("Unexpected status and/or body: {status} {body:?}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_extract_body() {
+        assert_eq!(
+            super::extract_body(include_str!("pwdgrp/add_10_12_initial_response.html"))
+                .unwrap()
+                .trim(),
+            "Created account root."
+        );
+    }
+}

--- a/crates/device-manager/src/vapix/axis_cgi/pwdgrp/add_10_12_initial_response.html
+++ b/crates/device-manager/src/vapix/axis_cgi/pwdgrp/add_10_12_initial_response.html
@@ -1,0 +1,4 @@
+<html><head><title>User accounts</title></head><body bgcolor=#ffffff>Created account root.
+</body>
+
+</html>

--- a/crates/device-manager/src/vapix/config.rs
+++ b/crates/device-manager/src/vapix/config.rs
@@ -1,0 +1,1 @@
+pub mod ssh1;

--- a/crates/device-manager/src/vapix/config/ssh1.rs
+++ b/crates/device-manager/src/vapix/config/ssh1.rs
@@ -1,0 +1,76 @@
+use std::ops::Deref;
+
+use anyhow::{bail, Context};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct CreateUser {
+    username: String,
+    password: String,
+    comment: String,
+}
+#[derive(Serialize, Deserialize)]
+struct UpdateUser {
+    password: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RequestEnvelope<T> {
+    data: T,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ResponseEnvelope {
+    pub status: String,
+    pub data: Option<String>,
+}
+pub async fn update_user(
+    client: &acap_vapix::HttpClient,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<()> {
+    let request_envelope = RequestEnvelope {
+        data: UpdateUser {
+            password: password.to_string(),
+        },
+    };
+    let builder = client
+        .put(&format!("config/rest/ssh/v1/users/{username}"))
+        .unwrap()
+        .replace_with(|b| b.json(&request_envelope));
+    let resp = builder.send().await?;
+    let status = resp.status();
+    let text = resp.text().await?;
+    let body: ResponseEnvelope = serde_json::from_str(&text).context(text.to_string())?;
+    if (status, body.status.deref()) != (StatusCode::OK, "success") {
+        bail!("Server returned error: {status} {text:?}")
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_serialize_update_request() {
+        let req = RequestEnvelope {
+            data: UpdateUser {
+                password: "pass".to_string(),
+            },
+        };
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            r#"{"data":{"password":"pass"}}"#
+        )
+    }
+
+    #[test]
+    fn can_deserialize_update_response() {
+        let res = r#"{
+            "status": "success"
+        }"#;
+        let _: ResponseEnvelope = serde_json::from_str(res).unwrap();
+    }
+}


### PR DESCRIPTION
Being able to quickly restore a device to a known baseline makes it easier for me to do rigorous testing; removing apps manually is a hassle and may not be enough to undo the effects that development has had on a device either because I changed some setting or because an app did.

The variant of VAPIX used has diverged from that which was integrated as its own crate. Notable differences include:
- `acap-vapix` uses builder style public interfaces. These are closer to what I expect the final result will look like since they allow greater flexibility in use and evolution.
- `acap-vapix` draws the line between request and client in a way that gives the APIs less control over things like headers. This is better aligned with how many APIs since they are ignorant of headers, including authentication headers, which is something a user likely wants to control independently of which API is being used.
- `device-manager` is no longer parsing AJR responses as enum because this resulted in more boilerplate and is not helpful when the transport is already request-response based as HTTP is. The reason for using enums was that one intent of protocols like AJR is that they should be transport agnostic and work over WebSocket just as well as HTTP. As of writing I'm leaning towards a third framework that separates the envelope parsing and serialization from that of the data, errors, and parameters.

Because I am happy with neither branch and I don't want to refactor bindings twice, they are not moved except for parameter management which is less dependent on diverging code, has an API that is easier to adapt, and is more in demand.
