### PR TITLE
feat(acap-vapix): Create client from env on host

### DIFF
--- a/crates/acap-vapix/src/lib.rs
+++ b/crates/acap-vapix/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use std::{
+    env,
     io::Read,
     process::{Command, Stdio},
 };
@@ -16,8 +17,7 @@ mod ajr_http;
 mod apis;
 mod http;
 
-/// Construct a new [`HttpClient`] for ACAP apps connecting to VAPIX on the same device.
-pub fn local_client() -> anyhow::Result<HttpClient> {
+fn from_dbus() -> anyhow::Result<HttpClient> {
     // TODO: Consider verifying the manifest or providing hints when it looks misconfigured and this
     //  call fails.
     // TODO: Consider using a DBUs library like `zbus`
@@ -54,8 +54,31 @@ pub fn local_client() -> anyhow::Result<HttpClient> {
         .context("Expected dbus response to end with ')")?
         .split_once(':')
         .context("Expected dbus response to contain at least one :")?;
+    debug!("Creating client using username {username} from dbus");
+    Ok(
+        HttpClient::new(Url::parse("http://127.0.0.12").expect("Hardcoded url is valid"))
+            .basic_auth(username, password),
+    )
+}
 
-    debug!("Creating client using username {username}");
-    Ok(HttpClient::new(Url::parse("http://127.0.0.12")?)
-        .basic_auth(username.to_string(), password.to_string()))
+fn from_env() -> anyhow::Result<HttpClient> {
+    let username = env::var("AXIS_DEVICE_USER")?;
+    let password = env::var("AXIS_DEVICE_PASS")?;
+    let host = env::var("AXIS_DEVICE_IP")?;
+    let url = Url::parse(&format!("http://{host}"))?;
+    debug!("Creating client using username {username} from env");
+    // TODO: Select appropriate authentication scheme
+    // When connecting locally basic is always used but when connecting remotely the default is
+    // currently digest, so it would be convenient if that was applied to the client.
+    Ok(HttpClient::new(url).basic_auth(username, password))
+}
+
+/// Construct a new [`HttpClient`] for ACAP apps connecting to VAPIX.
+pub fn local_client() -> anyhow::Result<HttpClient> {
+    // TODO: Find a more robust configuration
+    if cfg!(target_arch = "x86_64") {
+        from_env()
+    } else {
+        from_dbus()
+    }
 }

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -2,7 +2,7 @@ use std::{env, fs::File};
 
 use clap::{Parser, Subcommand};
 use device_manager::{initialize, restore};
-use log::debug;
+use log::{debug, info};
 use url::Host;
 
 /// Utilities for managing individual devices.
@@ -74,8 +74,13 @@ async fn main() -> anyhow::Result<()> {
     };
     debug!("Logging initialized");
 
+    // TODO: Save logs on SIGINT.
+    // This program often fails
     match Cli::parse().exec().await {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            info!("Orl Korrect");
+            Ok(())
+        }
         Err(e) => {
             if let Some(log_file) = log_file {
                 Err(e.context(format!("A detailed log has been saved to {log_file:?}")))

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -74,8 +74,13 @@ async fn main() -> anyhow::Result<()> {
     };
     debug!("Logging initialized");
 
+    // There are probably many places where this program could get stuck, such as when waiting for
+    // a parameter to change, and even when it succeeds it takes a long time. Interrupting it causes
+    // it to exit without writing logs to disk, so if they were not printed to stderr information
+    // about where the program was interrupted is lost. This makes it harder to find and report
+    // problems.
+    // TODO: Find and bound unbounded retry loops
     // TODO: Save logs on SIGINT.
-    // This program often fails
     match Cli::parse().exec().await {
         Ok(()) => {
             info!("Orl Korrect");


### PR DESCRIPTION
With this change it is possible to compile an app for host and run it without modifications, provided that:
- The necessary environment variables are set.
- The device is configured accordingly, and with the authentication policy set to basic.

In `crates/acap-vapix/src/lib.rs`:
- Include both code paths at compilation time because also making imports conditional to satisfy the linter is annoying. The two reasons I can think of to not do this are:
  - The compiler is not able to optimize away the unused path making the binary bigger (I don't know if this is the case, but so far I am not tackling binary sizes).
  - One branch has dependencies that the other does not (not the case here since both branches depend on `anyhow` and `std`).

In `crates/device-manager/src/main.rs`:
- Set the authentication policy to basic during initialization. This degrades the security significantly since it is also configured to accept HTTP requests that are not encrypted. While not optimal I also don't think it is terrible because it is probably not the only way we degrade the security of development devices, and they should be on a network where this is acceptable. The reason for doing this is that I have not yet figured out how to do certain things with digest authentication and I want the initialization procedure to make the device ready for testing as much as possible. The things I have not figured out are web socket upgrades and installing applications and firmware (multipart requests don't implement `Clone`).
- Update `wait_for_param` to not panic and actually check the parameter because when I forgot to set the authentication policy before waiting for it, the program exited without saving any logs. This is wrong for two reasons; it should have kept trying and it should not have exited without saving logs.
- Mutate a single client variable instead of moving the client between variables because we don't really care how we authenticate, and changing which variable is used depending on how the device has been setup is annoying and results in unnecessary diffs.
- Log something right before exit to make it evident to a human user that it was successful.