### PR TITLE
feat(acap-vapix): Add basic device information API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,9 @@ test:
 	acap-ssh-utils run-app \
 		--environment RUST_LOG=debug \
 		--environment RUST_LOG_STYLE=always \
-		$(AXIS_PACKAGE)
+		$(AXIS_PACKAGE) \
+		-- \
+		--test-threads=1
 
 ## Checks
 ## ------

--- a/apps/vapix_access/src/main.rs
+++ b/apps/vapix_access/src/main.rs
@@ -31,9 +31,37 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use acap_vapix::{
-        parameter_management, systemready, ws_data_stream,
+        basic_device_info, parameter_management, systemready, ws_data_stream,
         ws_data_stream::{ContentFilter, TopicFilter},
     };
+
+    #[tokio::test]
+    async fn smoke_test_basic_device_info() {
+        let mut client = acap_vapix::local_client().unwrap();
+
+        let properties = basic_device_info::Client::new(&client)
+            .get_all_properties()
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(properties.property_list.unrestricted.brand, "AXIS");
+
+        let properties = basic_device_info::Client::new(&client)
+            .get_properties(&["Brand"])
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(properties.property_list.get("Brand").unwrap(), "AXIS");
+
+        client = client.anonymous_auth();
+
+        let properties = basic_device_info::Client::new(&client)
+            .get_all_unrestricted_properties()
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(properties.property_list.brand, "AXIS");
+    }
 
     #[tokio::test]
     async fn smoke_test_parameter_management() {

--- a/crates/acap-ssh-utils/src/lib.rs
+++ b/crates/acap-ssh-utils/src/lib.rs
@@ -156,6 +156,7 @@ pub fn run_other(
     pass: &str,
     host: &Host,
     env: HashMap<&str, &str>,
+    args: &[&str],
 ) -> anyhow::Result<()> {
     let temp_file = RemoteTemporaryFile::try_new(user, pass, host)?;
 
@@ -163,6 +164,7 @@ pub fn run_other(
 
     let mut exec = std::process::Command::new(&temp_file.path);
     exec.envs(env);
+    exec.args(args);
 
     let mut ssh_exec = ssh(user, pass, host);
     ssh_exec.arg(format!("{exec:?}"));
@@ -191,6 +193,7 @@ pub fn run_package(
     host: &Host,
     package: &str,
     env: HashMap<&str, &str>,
+    args: &[&str],
 ) -> anyhow::Result<()> {
     let mut cd = std::process::Command::new("cd");
     cd.arg(format!("/usr/local/packages/{package}"));
@@ -199,6 +202,7 @@ pub fn run_package(
     // TODO: Consider setting more environment variables
     exec.env("G_SLICE", "always-malloc");
     exec.envs(env);
+    exec.args(args);
 
     let package_user = format!("acap-{package}");
     let exec_as_package = if user == package_user {

--- a/crates/acap-ssh-utils/src/main.rs
+++ b/crates/acap-ssh-utils/src/main.rs
@@ -79,6 +79,8 @@ struct RunApp {
     #[clap(short, long)]
     #[arg(value_parser = parse_env_pair)]
     environment: Vec<(String, String)>,
+    /// Pass additional arguments to the remote program.
+    args: Vec<String>,
 }
 
 impl RunApp {
@@ -92,6 +94,7 @@ impl RunApp {
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect(),
+            &self.args.iter().map(String::as_str).collect::<Vec<_>>(),
         )
     }
 }
@@ -106,6 +109,8 @@ struct RunOther {
     #[clap(short, long)]
     #[arg(value_parser = parse_env_pair)]
     environment: Vec<(String, String)>,
+    /// Pass additional arguments to the remote program.
+    args: Vec<String>,
 }
 
 impl RunOther {
@@ -119,6 +124,7 @@ impl RunOther {
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect(),
+            &self.args.iter().map(String::as_str).collect::<Vec<_>>(),
         )
     }
 }

--- a/crates/acap-vapix/README.md
+++ b/crates/acap-vapix/README.md
@@ -32,6 +32,7 @@ This table is an attempt at providing an overview of what exists and how usable 
 
 | Name                           | Methods | Status       |
 |--------------------------------|---------|--------------|
+| Basic device information       | 2/4     | Experimental |
 | Event streaming over WebSocket | 1/1     | Experimental |
 | Parameter management           | 2/5     | Experimental |
 | Systemready                    | 1/2     | Experimental |

--- a/crates/acap-vapix/src/ajr.rs
+++ b/crates/acap-vapix/src/ajr.rs
@@ -12,6 +12,16 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestEnvelope<P> {
+    api_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+    #[serde(flatten)]
+    params: P,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResponseEnvelope<T> {

--- a/crates/acap-vapix/src/ajr2.rs
+++ b/crates/acap-vapix/src/ajr2.rs
@@ -57,14 +57,26 @@ mod tests {
         let envelope: ResponseEnvelope<()> = serde_json::from_str(s).unwrap();
         envelope.data().unwrap();
     }
+
     #[test]
     #[ignore]
     #[should_panic]
-    /// Documents the fact that this implementation is incapable of (de)serializing a responses with
+    /// Documents the fact that this implementation is incapable of (de)serializing a response with
     /// no member named either _data_ or _error_, which some VAPIX APIs use to signal that a request
     /// was successful.
     fn can_parse_missing_data_response() {
         let s = r#"{"apiVersion":"1.0","method":"events:configure"}"#;
+        let envelope: ResponseEnvelope<()> = serde_json::from_str(s).unwrap();
+        envelope.data().unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    #[should_panic]
+    /// Documents the fact that this implementation is incapable of (de)serializing a request with
+    /// no member named _param_, which some VAPIX APIs use for requests that have no params.
+    fn can_parse_missing_param_request() {
+        let s = r#"{"apiVersion":"1.3","method":"getAllUnrestrictedProperties"}"#;
         let envelope: ResponseEnvelope<()> = serde_json::from_str(s).unwrap();
         envelope.data().unwrap();
     }

--- a/crates/acap-vapix/src/ajr_http2.rs
+++ b/crates/acap-vapix/src/ajr_http2.rs
@@ -6,28 +6,8 @@ use std::fmt::Debug;
 use anyhow::Context;
 use log::debug;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
-use crate::ajr::ResponseEnvelope;
-
-pub async fn execute_params<S, D>(
-    path: &str,
-    api_version: &str,
-    method: &str,
-    params: S,
-    client: &crate::http::Client,
-) -> anyhow::Result<D>
-where
-    S: Serialize + Debug,
-    D: for<'a> Deserialize<'a>,
-{
-    let request_envelope = json!({
-        "method": method,
-        "apiVersion": api_version,
-        "params": params,
-    });
-    execute_request(path, request_envelope, client).await
-}
+use crate::ajr2::ResponseEnvelope;
 
 pub async fn execute_request<S, D>(
     path: &str,

--- a/crates/acap-vapix/src/apis.rs
+++ b/crates/acap-vapix/src/apis.rs
@@ -1,5 +1,6 @@
 //! A collection of bindings for individual APIs.
 pub mod parameter_management;
 
+pub mod basic_device_info;
 pub mod systemready;
 pub mod ws_data_stream;

--- a/crates/acap-vapix/src/apis/basic_device_info.rs
+++ b/crates/acap-vapix/src/apis/basic_device_info.rs
@@ -1,0 +1,180 @@
+//! Bindings for the [Basic device information](https://www.axis.com/vapix-library/subjects/t10175981/section/t10132180/display) API.
+// TODO: Return actionable errors.
+// TODO: Implement `getSupportedVersions`.
+// TODO: Proper documentation.
+// TODO: Consider adding support for checking if the API should be present
+use std::{collections::HashMap, fmt::Display};
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::{ajr_http2, HttpClient};
+
+const PATH: &str = "axis-cgi/basicdeviceinfo.cgi";
+
+const API_VERSION: &str = "1.0";
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAllPropertiesData {
+    pub property_list: PropertyList,
+}
+#[derive(Debug)]
+pub struct GetAllPropertiesRequest<'a> {
+    client: &'a HttpClient,
+}
+
+impl<'a> GetAllPropertiesRequest<'a> {
+    pub async fn send(self) -> anyhow::Result<GetAllPropertiesData> {
+        ajr_http2::execute_request(
+            PATH,
+            json!({
+                "apiVersion": API_VERSION,
+                "method": "getAllProperties",
+            }),
+            self.client,
+        )
+        .await
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAllUnrestrictedPropertiesData {
+    pub property_list: UnrestrictedPropertyList,
+}
+#[derive(Debug)]
+pub struct GetAllUnrestrictedPropertiesRequest<'a> {
+    client: &'a HttpClient,
+}
+
+impl<'a> GetAllUnrestrictedPropertiesRequest<'a> {
+    pub async fn send(self) -> anyhow::Result<GetAllUnrestrictedPropertiesData> {
+        ajr_http2::execute_request(
+            PATH,
+            json!({
+                "apiVersion": API_VERSION,
+                "method": "getAllUnrestrictedProperties",
+            }),
+            self.client,
+        )
+        .await
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetPropertiesData {
+    pub property_list: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+pub struct GetPropertiesRequest<'a> {
+    client: &'a HttpClient,
+    property_list: Vec<String>,
+}
+
+// TODO: Consider helping users discover properties by using an enum or methods.
+impl<'a> GetPropertiesRequest<'a> {
+    pub async fn send(self) -> anyhow::Result<GetPropertiesData> {
+        ajr_http2::execute_request(
+            PATH,
+            json!({
+                "apiVersion": API_VERSION,
+                "method": "getProperties",
+                "params": {"propertyList":self.property_list}
+            }),
+            self.client,
+        )
+        .await
+    }
+}
+
+// TODO: Consider exposing a flat struct
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct PropertyList {
+    #[serde(flatten)]
+    pub restricted: RestrictedPropertyList,
+    #[serde(flatten)]
+    pub unrestricted: UnrestrictedPropertyList,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RestrictedPropertyList {
+    pub architecture: String,
+    pub soc: String,
+    pub soc_serial_number: String,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct UnrestrictedPropertyList {
+    pub brand: String,
+    pub build_date: String,
+    #[serde(rename = "HardwareID")]
+    pub hardware_id: String,
+    pub prod_full_name: String,
+    pub prod_nbr: String,
+    pub prod_short_name: String,
+    pub prod_type: String,
+    pub prod_variant: String,
+    pub serial_number: String,
+    pub version: String,
+    #[serde(rename = "WebURL")]
+    pub web_url: String,
+}
+
+pub struct Client<'a>(&'a HttpClient);
+
+impl<'a> Client<'a> {
+    pub fn new(http_client: &'a HttpClient) -> Self {
+        Self(http_client)
+    }
+
+    pub fn get_properties(&self, properties: &[impl Display]) -> GetPropertiesRequest {
+        GetPropertiesRequest {
+            client: self.0,
+            property_list: properties.iter().map(ToString::to_string).collect(),
+        }
+    }
+
+    /// Fetch all properties.
+    ///
+    /// Please see the VAPIX Library documentation for [getAllProperties](https://www.axis.com/vapix-library/subjects/t10175981/section/t10132180/display?section=t10132180-t10132250).
+    pub fn get_all_properties(&self) -> GetAllPropertiesRequest {
+        GetAllPropertiesRequest { client: self.0 }
+    }
+
+    /// Fetch the subset of properties that are available without authentication.
+    ///
+    /// Please see the VAPIX Library documentation for [getAllUnrestrictedProperties](https://www.axis.com/vapix-library/subjects/t10175981/section/t10132180/display?section=t10132180-t10160656).
+    pub fn get_all_unrestricted_properties(&self) -> GetAllUnrestrictedPropertiesRequest {
+        GetAllUnrestrictedPropertiesRequest { client: self.0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ajr2::ResponseEnvelope;
+
+    #[test]
+    fn can_serialize_responses() {
+        let texts = vec![include_str!(
+            "basic_device_info/get_all_unrestricted_properties_10_12_initial_response.json"
+        )];
+        for text in texts {
+            let resp: ResponseEnvelope<GetAllUnrestrictedPropertiesData> =
+                serde_json::from_str(text).unwrap();
+            println!("{}", serde_json::to_string(&resp).unwrap());
+        }
+    }
+}

--- a/crates/acap-vapix/src/apis/basic_device_info/get_all_unrestricted_properties_10_12_initial_response.json
+++ b/crates/acap-vapix/src/apis/basic_device_info/get_all_unrestricted_properties_10_12_initial_response.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "1.3",
+  "data": {
+    "propertyList": {
+      "ProdNbr": "P8815-2",
+      "HardwareID": "7C5",
+      "ProdFullName": "AXIS P8815-2 3D People Counter",
+      "Version": "10.12.228",
+      "ProdType": "3D People Counter",
+      "Brand": "AXIS",
+      "WebURL": "http://www.axis.com",
+      "ProdVariant": "",
+      "SerialNumber": "1234567890AB",
+      "ProdShortName": "AXIS P8815-2",
+      "BuildDate": "Feb 23 2024 22:15"
+    }
+  }
+}

--- a/crates/acap-vapix/src/lib.rs
+++ b/crates/acap-vapix/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use anyhow::{bail, Context};
-pub use apis::{parameter_management, systemready, ws_data_stream};
+pub use apis::{basic_device_info, parameter_management, systemready, ws_data_stream};
 pub use http::Client as HttpClient;
 use log::debug;
 use url::Url;
@@ -15,6 +15,7 @@ use url::Url;
 mod ajr;
 mod ajr2;
 mod ajr_http;
+mod ajr_http2;
 mod apis;
 mod http;
 


### PR DESCRIPTION
`Makefile`:
- Set `--test-threads=1` when running tests on target because oftentimes these tests will be using scarce resources in which case running them in parallel may result in consistent or sporadic failures. In this case it seems that when a second test requests credentials using the same name (I have not tested using different names), either the old or the old credentials are invalidated causing the test to because of HTTP status code 401.

`crates/acap-ssh-utils/src/lib.rs`:
- Add `args` argument primarily to allow setting `--test-threads` when running tests.

`crates/acap-vapix/src/ajr_http.rs`:
- This function was originally split to make it usable from basic device info, which uses a request that cannot be serialized with the existing envelope model. I kept the split after moving to `ajr_http2` to make it easier to compare the two implementations.

`crates/acap-vapix/src/ajr_http2.rs`:
- Added for the same reason as `ajr2`.
- Though this looks like an identical copy, it uses types from `ajr2` instead of `ajr` and I don't want to spend time lifting out any patterns since the plan is to remove one of them.

`crates/acap-vapix/src/apis/basic_device_info.rs`:
- This module explores a slightly different take on making bindings; instead of representing each method with a function and binding the client at the end, the client is bound at the start and the methods are methods on said client. Pros and cons include:
  - Pro: Seems more common which means it should be more familiar. Examples include `reqwests`, the AWS SDK, tarpc, octocrap and the Azure SDK. The latter two expose a hierarchy of clients which is something I'm considering as well. The reason I have not done it so far is that from a similar project in project in Python I learned that it is annoying having to provide information that is not used and may not be available. That targeted HTTP, SSH and WebSocket APIs, so it may not be completely applicable, but I would still explore the multi protocol APIs, such as `media.amp` before committing.
  - Con: Building the request becomes coupled to executing the request. I have found it annoying that `reqwests`, so maybe users of this API will also find it annoying. My reason was that it made it harder for me to build AJR requests, convert them into HTTP requests, and execute them.
- Request types take the client by reference because it seems that requests are usually built and executed in close proximity. If this turns out to be annoying I think cloning `reqwest::Client` is cheap, and the wrapper client doesn't store much additional data.
- `AllPropertiesList` is normalized into two sub-lists because to reduce the amount of code and highlight the differences compared to `AllUnrestrictedPropertiesList`. Since unpacking the nesting is can be annoying and the underlying API looks different we may want to flatten this.

`get_all_unrestricted_properties_10_12_initial_response.json`:
- Don't use a real serial number because even though that is neither personal nor private afaik, it seems unnecessary to publish.
- Make up a serial number where the second digit is 2 because this should map to a locally administered mac address, so no one else should be able to claim that it is theirs.