### PR TITLE
fix: Add prerequisites and update docstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ stop:
 ## * The app is installed on the device.
 ## * The app is stopped.
 ## * The device has SSH enabled the ssh user root configured.
-## * The device is added to `knownhosts`.
 run: apps/$(AXIS_PACKAGE)/LICENSE
 	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE)
 	acap-ssh-utils patch target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)/*.eap
@@ -117,7 +116,6 @@ run: apps/$(AXIS_PACKAGE)/LICENSE
 ## * The app is installed on the device.
 ## * The app is stopped.
 ## * The device has SSH enabled the ssh user root configured.
-## * The device is added to `knownhosts`.
 test: apps/$(AXIS_PACKAGE)/LICENSE
 	# The `scp` command below needs the wildcard to match exactly one file.
 	rm -r target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)-*/$(AXIS_PACKAGE) ||:

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ stop:
 ## * The app is stopped.
 ## * The device has SSH enabled the ssh user root configured.
 ## * The device is added to `knownhosts`.
-run:
+run: apps/$(AXIS_PACKAGE)/LICENSE
 	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE)
 	acap-ssh-utils patch target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)/*.eap
 	acap-ssh-utils run-app \
@@ -118,7 +118,7 @@ run:
 ## * The app is stopped.
 ## * The device has SSH enabled the ssh user root configured.
 ## * The device is added to `knownhosts`.
-test:
+test: apps/$(AXIS_PACKAGE)/LICENSE
 	# The `scp` command below needs the wildcard to match exactly one file.
 	rm -r target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)-*/$(AXIS_PACKAGE) ||:
 	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE) --tests


### PR DESCRIPTION
Essentially any target that uses `cargo-acap-build` needs this prerequisite because it will try to use `acap-build` which fails if there is no `LICENSE` file.

The cause of it being omitted is probably that I didn't think enough about which targets needed it and since `make build` usually precedes `make run` and `make test` without cleaning the repository between, these targets appeared to work.