### PR TITLE
feat!: Add cargo-acap-sdk tool

### DIFF
--- a/.devhost/install-venv.sh
+++ b/.devhost/install-venv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -eu
+set -eux
 
 VIRTUAL_ENV="${1}"
 INIT_ENV="${2:-}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "flate2",
  "log",
@@ -331,12 +331,27 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "home",
  "log",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "cargo-acap-sdk"
+version = "0.0.0"
+dependencies = [
+ "acap-ssh-utils",
+ "anyhow",
+ "cargo-acap-build",
+ "clap",
+ "clap_complete",
+ "dirs 5.0.1",
+ "env_logger",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -401,6 +416,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ae69fbb0833c6fcd5a8d4b8609f108c7ad95fc11e248d853ff2c42a90df26a"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -503,7 +527,7 @@ dependencies = [
  "acap-vapix",
  "anyhow",
  "clap",
- "dirs",
+ "dirs 3.0.2",
  "env_logger",
  "log",
  "regex",
@@ -551,11 +575,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,23 @@ test: apps/$(AXIS_PACKAGE)/LICENSE
 		-- \
 		--test-threads=1
 
+## Bulk operations
+## ---------------
+
+## Install all apps on <AXIS_DEVICE_IP> using password <AXIS_DEVICE_PASS> and assuming architecture <AXIS_DEVICE_ARCH>
+install_all: $(patsubst %/,%/LICENSE,$(wildcard apps/*/))
+	cargo-acap-sdk install \
+		-- \
+		--package licensekey \
+		--package '*_*'
+
+## Build and execute unit tests for all apps on <AXIS_DEVICE_IP> assuming architecture <AXIS_DEVICE_ARCH>
+test_all: $(patsubst %/,%/LICENSE,$(wildcard apps/*/))
+	cargo-acap-sdk test \
+		-- \
+		--package licensekey \
+		--package '*_*'
+
 ## Checks
 ## ------
 

--- a/apps/consume_analytics_metadata/src/main.rs
+++ b/apps/consume_analytics_metadata/src/main.rs
@@ -83,7 +83,7 @@ mod tests {
         )
         .unwrap();
 
-        let payload = rx.recv_timeout(Duration::from_secs(5)).unwrap().unwrap();
+        let payload = rx.recv_timeout(Duration::from_secs(10)).unwrap().unwrap();
         assert!(!payload.is_empty());
         println!("{payload}");
     }

--- a/crates/cargo-acap-build/src/cargo_acap.rs
+++ b/crates/cargo-acap-build/src/cargo_acap.rs
@@ -14,7 +14,12 @@ use crate::{
     command_utils::RunWith,
 };
 
-pub fn build_and_pack(arch: Architecture, args: &[&str]) -> anyhow::Result<Vec<PathBuf>> {
+#[derive(Debug)]
+pub enum Artifact {
+    Eap { path: PathBuf, name: String },
+    Exe { path: PathBuf },
+}
+pub fn build_and_pack(arch: Architecture, args: &[&str]) -> anyhow::Result<Vec<Artifact>> {
     // If user supplies a target we lose track of which target is currently being built
     assert!(!args.contains(&"--target"));
 
@@ -60,17 +65,20 @@ pub fn build_and_pack(arch: Architecture, args: &[&str]) -> anyhow::Result<Vec<P
                 let out_dir = out_dirs.get(&package_id).cloned();
                 if is_app(&manifest_path, out_dir.as_deref()) {
                     // If the executable should be an ACAP app, create an `.eap` file.
-                    artifacts.push(pack(
-                        &cargo_target_directory,
-                        arch,
-                        target.name,
-                        manifest_path,
-                        executable,
-                        out_dir,
-                    )?);
+                    artifacts.push(Artifact::Eap {
+                        path: pack(
+                            &cargo_target_directory,
+                            arch,
+                            target.name.clone(),
+                            manifest_path,
+                            executable,
+                            out_dir,
+                        )?,
+                        name: target.name,
+                    });
                 } else {
                     // If the executable should not be an ACAP app, leave it as is.
-                    artifacts.push(executable);
+                    artifacts.push(Artifact::Exe { path: executable });
                 }
             }
             JsonMessage::CompilerMessage { message } => {

--- a/crates/cargo-acap-build/src/lib.rs
+++ b/crates/cargo-acap-build/src/lib.rs
@@ -1,18 +1,106 @@
 #![doc=include_str!("../README.md")]
-use std::path::PathBuf;
+
+use std::{
+    fmt::Display,
+    fs, mem,
+    path::{Path, PathBuf},
+};
 
 pub use acap::Architecture;
+pub use cargo::get_cargo_metadata;
+pub use cargo_acap::Artifact;
+use log::debug;
 
 mod acap;
 mod cargo;
 mod cargo_acap;
 mod command_utils;
 
-pub use cargo::get_cargo_metadata;
-pub fn build(targets: &[Architecture], args: &[&str]) -> anyhow::Result<Vec<PathBuf>> {
-    let mut artifacts = Vec::new();
-    for target in targets {
-        artifacts.extend(cargo_acap::build_and_pack(*target, args)?);
+pub struct AppBuilder {
+    targets: Vec<Architecture>,
+    args: Vec<String>,
+    artifact_dir: Option<PathBuf>,
+}
+
+impl AppBuilder {
+    pub fn from_targets<T, U>(targets: T) -> Self
+    where
+        T: IntoIterator<Item = U>,
+        U: Into<Architecture>,
+    {
+        Self {
+            targets: targets.into_iter().map(|t| t.into()).collect(),
+            args: Vec::new(),
+            artifact_dir: None,
+        }
     }
-    Ok(artifacts)
+
+    /// Add arguments that will be passed through to cargo.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it detects one of the disallowed options:
+    /// - `--artifact-dir`
+    /// - `--target`
+    ///
+    /// <div class="warning">
+    ///     Disallowing more options will not be considered a breaking change!
+    /// </div>
+    pub fn args<T, U>(&mut self, args: T) -> &mut Self
+    where
+        T: IntoIterator<Item = U>,
+        U: Display,
+    {
+        self.args.extend(args.into_iter().map(|arg| {
+            let arg: String = arg.to_string();
+            let name = arg.split('=').next().unwrap();
+            assert_ne!(name, "--artifact-dir");
+            assert_ne!(name, "--target");
+            arg
+        }));
+        self
+    }
+
+    /// Copy final artifacts to this directory.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the artifact dir has already been set.
+    pub fn artifact_dir<T>(&mut self, artifact_dir: T) -> &mut Self
+    where
+        T: Into<PathBuf>,
+    {
+        assert!(mem::replace(&mut self.artifact_dir, Some(artifact_dir.into())).is_none());
+        self
+    }
+
+    pub fn execute(&mut self) -> anyhow::Result<Vec<Artifact>> {
+        let args: Vec<_> = self.args.iter().map(String::as_str).collect();
+        let mut artifacts = Vec::new();
+        for target in &self.targets {
+            artifacts.extend(cargo_acap::build_and_pack(*target, &args)?);
+        }
+        if let Some(artifact_dir) = self.artifact_dir.as_deref() {
+            copy_final_artifacts(&artifacts, artifact_dir)?;
+        }
+        Ok(artifacts)
+    }
+}
+
+fn copy_final_artifacts(artifacts: &[Artifact], acap_dir: &Path) -> anyhow::Result<()> {
+    match fs::create_dir(acap_dir) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => Err(e)?,
+    }
+    for artifact in artifacts {
+        let Artifact::Eap { path: src, name } = artifact else {
+            debug!("Skipping artifact that is not an EAP: {artifact:?}");
+            continue;
+        };
+        let dst = acap_dir.join(name);
+        debug!("Copying `.eap` from {src:?} to {dst:?}");
+        fs::copy(src, dst)?;
+    }
+    Ok(())
 }

--- a/crates/cargo-acap-sdk/Cargo.toml
+++ b/crates/cargo-acap-sdk/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cargo-acap-sdk"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.79"
+clap = { version = "4.5.1", features = ["derive"] }
+clap_complete = "4.5.2"
+dirs = "5.0.1"
+env_logger = "0.11.1"
+log = "0.4.17"
+url = "2.5.0"
+
+acap-ssh-utils = { path = "../acap-ssh-utils" }
+cargo-acap-build = { path = "../cargo-acap-build" }

--- a/crates/cargo-acap-sdk/README.md
+++ b/crates/cargo-acap-sdk/README.md
@@ -1,0 +1,18 @@
+```console
+$ cargo-acap-sdk -h
+Tools for developing ACAP apps using Rust
+
+Usage: cargo-acap-sdk <COMMAND>
+
+Commands:
+  build        Build app(s) with release profile
+  run          Build app(s) and run on the device
+  test         Build app(s) in test mode and run on the device
+  install      Build app(s) with release profile and install on the device
+  completions  Print shell completion script for this program
+  help         Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```

--- a/crates/cargo-acap-sdk/src/command_utils.rs
+++ b/crates/cargo-acap-sdk/src/command_utils.rs
@@ -1,0 +1,92 @@
+use std::io::{BufRead, BufReader, Read};
+
+use log::{debug, warn};
+
+pub trait RunWith {
+    fn run_with_captured_stdout(self) -> anyhow::Result<String>;
+    fn run_with_processed_stdout(
+        self,
+        func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()>;
+    fn run_with_logged_stdout(self) -> anyhow::Result<()>;
+    fn run_with_inherited_stdout(self) -> anyhow::Result<()>;
+}
+
+fn spawn(mut cmd: std::process::Command) -> anyhow::Result<std::process::Child> {
+    Ok(cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            let program = cmd.get_program().to_string_lossy().to_string();
+            warn!("Don't forget to install {program}");
+        }
+        e
+    })?)
+}
+
+impl RunWith for std::process::Command {
+    fn run_with_captured_stdout(mut self) -> anyhow::Result<String> {
+        self.stdout(std::process::Stdio::piped());
+        debug!("Spawning child {self:#?}...");
+        let mut child = spawn(self)?;
+        let mut stdout = child.stdout.take().unwrap();
+        debug!("Waiting for child...");
+        let status = child.wait()?;
+        if !status.success() {
+            anyhow::bail!("Child failed: {status}");
+        }
+        let mut decoded = String::new();
+        stdout.read_to_string(&mut decoded)?;
+        Ok(decoded)
+    }
+
+    fn run_with_processed_stdout(
+        mut self,
+        mut func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        self.stdout(std::process::Stdio::piped());
+        debug!("Spawning child {self:#?}...");
+        let mut child = spawn(self)?;
+        let stdout = child.stdout.take().unwrap();
+
+        let lines = BufReader::new(stdout).lines();
+        for line in lines {
+            func(line)?;
+        }
+
+        debug!("Waiting for child...");
+        let status = child.wait()?;
+        if !status.success() {
+            anyhow::bail!("Child failed: {status}");
+        }
+        Ok(())
+    }
+    fn run_with_logged_stdout(mut self) -> anyhow::Result<()> {
+        self.stdout(std::process::Stdio::piped());
+        debug!("Spawning child {self:#?}...");
+        let mut child = spawn(self)?;
+        let stdout = child.stdout.take().unwrap();
+
+        let lines = BufReader::new(stdout).lines();
+        for line in lines {
+            let line = line?;
+            if !line.is_empty() {
+                debug!("Child said {:?}.", line);
+            }
+        }
+
+        debug!("Waiting for child...");
+        let status = child.wait()?;
+        if !status.success() {
+            anyhow::bail!("Child failed: {status}");
+        }
+        Ok(())
+    }
+
+    fn run_with_inherited_stdout(mut self: std::process::Command) -> anyhow::Result<()> {
+        debug!("Running command {self:#?}...");
+        let status = self.status()?;
+        if !status.success() {
+            anyhow::bail!("Child failed: {status}");
+        }
+        Ok(())
+    }
+}

--- a/crates/cargo-acap-sdk/src/commands.rs
+++ b/crates/cargo-acap-sdk/src/commands.rs
@@ -1,0 +1,6 @@
+pub mod build_command;
+pub mod completions_command;
+
+pub mod install_command;
+pub mod run_command;
+pub mod test_command;

--- a/crates/cargo-acap-sdk/src/commands/build_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/build_command.rs
@@ -1,0 +1,34 @@
+use cargo_acap_build::{get_cargo_metadata, AppBuilder, Architecture};
+use log::debug;
+
+use crate::BuildOptions;
+
+#[derive(clap::Parser, Debug, Clone)]
+pub struct BuildCommand {
+    #[command(flatten)]
+    build_options: BuildOptions,
+}
+
+impl BuildCommand {
+    pub fn exec(self) -> anyhow::Result<()> {
+        let Self {
+            build_options: BuildOptions { target, mut args },
+        } = self;
+
+        if !args.iter().any(|arg| {
+            arg.split('=')
+                .next()
+                .expect("Split always yields at least one substring")
+                .starts_with("--profile")
+        }) {
+            debug!("Using release profile by default");
+            args.push("--profile=release".to_string());
+        }
+
+        AppBuilder::from_targets([Architecture::from(target)])
+            .args(args)
+            .artifact_dir(get_cargo_metadata()?.target_directory.join("acap"))
+            .execute()?;
+        Ok(())
+    }
+}

--- a/crates/cargo-acap-sdk/src/commands/completions_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/completions_command.rs
@@ -1,0 +1,16 @@
+use clap::{Command, Parser};
+use clap_complete::{generate, Shell};
+
+#[derive(Debug, Parser)]
+pub struct CompletionsCommand {
+    shell: Shell,
+}
+
+impl CompletionsCommand {
+    pub fn exec(self, mut cmd: Command) -> anyhow::Result<()> {
+        let Self { shell } = self;
+        let name = cmd.get_name().to_string();
+        generate(shell, &mut cmd, name, &mut std::io::stdout());
+        Ok(())
+    }
+}

--- a/crates/cargo-acap-sdk/src/commands/install_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/install_command.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+
+use anyhow::Context;
+use cargo_acap_build::{AppBuilder, Architecture, Artifact};
+use log::debug;
+
+use crate::{command_utils::RunWith, ArchAbi, BuildOptions, DeployOptions};
+
+#[derive(clap::Parser, Debug, Clone)]
+pub struct InstallCommand {
+    #[command(flatten)]
+    build_options: BuildOptions,
+    #[command(flatten)]
+    deploy_options: DeployOptions,
+}
+
+impl InstallCommand {
+    pub fn exec(self) -> anyhow::Result<()> {
+        let Self {
+            build_options: BuildOptions { target, mut args },
+            deploy_options,
+        } = self;
+
+        if !args.iter().any(|arg| {
+            arg.split('=')
+                .next()
+                .expect("Split always yields at least one substring")
+                .starts_with("--profile")
+        }) {
+            debug!("Using release profile by default");
+            args.push("--profile=release".to_string());
+        }
+
+        let artifacts = AppBuilder::from_targets([Architecture::from(target)])
+            .args(args)
+            .execute()?;
+
+        // TODO: Handle the case where multiple artifacts of the same kind have the same name.
+        for artifact in artifacts {
+            match artifact {
+                Artifact::Eap { path, .. } => install_one(target, &path, &deploy_options).unwrap(),
+                Artifact::Exe { path } => {
+                    debug!("Skipping exe {path:?}")
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn install_one(
+    architecture: ArchAbi,
+    app: &Path,
+    deploy_options: &DeployOptions,
+) -> anyhow::Result<()> {
+    // TODO: Run in temporary directory or reimplement in rust for better control.
+    let mut eap_install = std::process::Command::new("eap-install.sh");
+    eap_install.arg(deploy_options.host.to_string());
+    eap_install.arg(&deploy_options.pass);
+    eap_install.arg("install");
+    assert_eq!(&deploy_options.user, "root");
+
+    let app_dir = app.parent().context("app not in a directory")?;
+    let mut sh = std::process::Command::new("sh");
+    sh.current_dir(app_dir);
+
+    let env_setup = match architecture {
+        ArchAbi::Aarch64 => "environment-setup-cortexa53-crypto-poky-linux",
+        ArchAbi::Armv7hf => "environment-setup-cortexa9hf-neon-poky-linux-gnueabi",
+    };
+    sh.args([
+        "-c",
+        &format!(". /opt/axis/acapsdk/{env_setup} && {:?}", eap_install),
+    ]);
+    sh.run_with_logged_stdout()?;
+    Ok(())
+}

--- a/crates/cargo-acap-sdk/src/commands/run_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/run_command.rs
@@ -1,0 +1,52 @@
+use cargo_acap_build::{AppBuilder, Architecture, Artifact};
+use log::debug;
+
+use crate::{BuildOptions, DeployOptions};
+
+#[derive(clap::Parser, Debug, Clone)]
+pub struct RunCommand {
+    #[command(flatten)]
+    build_options: BuildOptions,
+    #[command(flatten)]
+    deploy_options: DeployOptions,
+}
+
+impl RunCommand {
+    pub fn exec(self) -> anyhow::Result<()> {
+        let Self {
+            build_options: BuildOptions { target, args },
+            deploy_options:
+                DeployOptions {
+                    host: address,
+                    user: username,
+                    pass: password,
+                },
+        } = self;
+
+        let artifacts = AppBuilder::from_targets([Architecture::from(target)])
+            .args(args)
+            .execute()?;
+        for artifact in artifacts {
+            let envs = vec![("RUST_LOG", "debug"), ("RUST_LOG_STYLE", "always")]
+                .into_iter()
+                .collect();
+            match artifact {
+                Artifact::Eap { path, name } => {
+                    // TODO: Install instead of patch when needed
+                    debug!("Patching app {name}");
+                    acap_ssh_utils::patch_package(&path, &username, &password, &address)?;
+                    debug!("Running app {name}");
+                    acap_ssh_utils::run_package(&username, &password, &address, &name, envs, &[])?
+                }
+                Artifact::Exe { path } => {
+                    debug!(
+                        "Running exe {}",
+                        path.file_name().unwrap().to_string_lossy()
+                    );
+                    acap_ssh_utils::run_other(&path, &username, &password, &address, envs, &[])?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/cargo-acap-sdk/src/commands/test_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/test_command.rs
@@ -1,0 +1,65 @@
+use cargo_acap_build::{AppBuilder, Architecture, Artifact};
+use log::debug;
+
+use crate::{BuildOptions, DeployOptions};
+
+#[derive(clap::Parser, Debug, Clone)]
+pub struct TestCommand {
+    #[command(flatten)]
+    build_options: BuildOptions,
+    #[command(flatten)]
+    deploy_options: DeployOptions,
+}
+
+impl TestCommand {
+    pub fn exec(self) -> anyhow::Result<()> {
+        let Self {
+            build_options:
+                BuildOptions {
+                    target,
+                    args: mut build_args,
+                },
+            deploy_options:
+                DeployOptions {
+                    host: address,
+                    user: username,
+                    pass: password,
+                },
+        } = self;
+
+        build_args.push("--tests".to_string());
+
+        let artifacts = AppBuilder::from_targets([Architecture::from(target)])
+            .args(build_args)
+            .execute()?;
+
+        for artifact in artifacts {
+            debug!("Running {:?}", artifact);
+            let envs = vec![("RUST_LOG", "debug"), ("RUST_LOG_STYLE", "always")]
+                .into_iter()
+                .collect();
+            let test_args = ["--test-threads=1"];
+            match artifact {
+                Artifact::Eap { path, name } => {
+                    // TODO: Install instead of patch when needed
+                    debug!("Patching app {name}");
+                    acap_ssh_utils::patch_package(&path, &username, &password, &address)?;
+                    debug!("Running app {name}");
+                    acap_ssh_utils::run_package(
+                        &username, &password, &address, &name, envs, &test_args,
+                    )?
+                }
+                Artifact::Exe { path } => {
+                    debug!(
+                        "Running exe {}",
+                        path.file_name().unwrap().to_string_lossy()
+                    );
+                    acap_ssh_utils::run_other(
+                        &path, &username, &password, &address, envs, &test_args,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/cargo-acap-sdk/src/main.rs
+++ b/crates/cargo-acap-sdk/src/main.rs
@@ -1,0 +1,143 @@
+use std::{ffi::OsString, fs::File};
+
+use cargo_acap_build::Architecture;
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use log::debug;
+use url::Host;
+
+use crate::commands::{
+    build_command::BuildCommand, completions_command::CompletionsCommand,
+    install_command::InstallCommand, run_command::RunCommand, test_command::TestCommand,
+};
+
+mod command_utils;
+
+mod commands;
+
+/// Tools for developing ACAP apps using Rust
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+impl Cli {
+    pub fn exec(self) -> anyhow::Result<()> {
+        match self.command {
+            Commands::Build(cmd) => cmd.exec()?,
+            Commands::Install(cmd) => cmd.exec()?,
+            Commands::Run(cmd) => cmd.exec()?,
+            Commands::Test(cmd) => cmd.exec()?,
+            Commands::Completions(cmd) => cmd.exec(Cli::command())?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Build app(s) with release profile.
+    Build(BuildCommand),
+    /// Build app(s) and run on the device.
+    Run(RunCommand),
+    /// Build app(s) in test mode and run on the device.
+    Test(TestCommand),
+    /// Build app(s) with release profile and install on the device.
+    Install(InstallCommand),
+    /// Print shell completion script for this program
+    ///
+    /// In `zsh` this can be used to enable completions in the current shell like
+    /// `cargo-acap-sdk completions zsh | source /dev/stdin`.
+    Completions(CompletionsCommand),
+}
+
+// TODO: Include package selection for better completions and help messages.
+#[derive(clap::Args, Debug, Clone)]
+struct BuildOptions {
+    // TODO: Query the device for its architecture.
+    /// Architecture of the device to build for.
+    #[arg(long, env = "AXIS_DEVICE_ARCH")]
+    target: ArchAbi,
+    /// Pass additional arguments to `cargo build`.
+    ///
+    /// Beware that not all incompatible arguments have been documented.
+    args: Vec<String>,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+struct DeployOptions {
+    /// Hostname or IP address of the device.
+    #[arg(long, value_parser = url::Host::parse, env="AXIS_DEVICE_IP")]
+    host: Host,
+    /// Username of SSH- and/or VAPIX-account to authenticate as.
+    ///
+    /// It is up to the user to ensure that these have been created on the device as needed.
+    #[clap(long, env = "AXIS_DEVICE_USER")]
+    user: String,
+    /// Password of SSH- and/or VAPIX-account to authenticate as.
+    ///
+    /// It is up to the user to ensure that these have been created on the device as needed.
+    // TODO: Consider disallowing passing password as arguments.
+    #[clap(long, env = "AXIS_DEVICE_PASS")]
+    pass: String,
+}
+
+// TODO: Figure out what to call this.
+// This is sometimes called just "architecture" but in other contexts arch refers to the first
+// part: https://clang.llvm.org/docs/CrossCompilation.html#target-triple
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+enum ArchAbi {
+    Aarch64,
+    Armv7hf,
+}
+
+impl From<ArchAbi> for Architecture {
+    fn from(val: ArchAbi) -> Self {
+        match val {
+            ArchAbi::Aarch64 => Architecture::Aarch64,
+            ArchAbi::Armv7hf => Architecture::Armv7hf,
+        }
+    }
+}
+
+fn normalized_args() -> Vec<OsString> {
+    let mut args: Vec<_> = std::env::args_os().collect();
+    if let Some(command) = args.get(1) {
+        if command.to_string_lossy() == "acap-sdk" {
+            args.remove(1);
+        }
+    }
+    args
+}
+
+fn main() -> anyhow::Result<()> {
+    let log_file = if std::env::var_os("RUST_LOG").is_none() {
+        if let Some(runtime_dir) = dirs::runtime_dir() {
+            let path = runtime_dir.join("cargo-acap-sdk.log");
+            let target = env_logger::Target::Pipe(Box::new(File::create(&path)?));
+            let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
+            builder.target(target).filter_level(log::LevelFilter::Debug);
+            builder.init();
+            Some(path)
+        } else {
+            None
+        }
+    } else {
+        env_logger::init();
+        None
+    };
+    debug!("Logging initialized");
+
+    match Cli::parse_from(normalized_args()).exec() {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if let Some(log_file) = log_file {
+                Err(e.context(format!("A detailed log has been saved to {log_file:?}")))
+            } else {
+                Err(e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
`crates/cargo-acap-build/`:
- Rewrite to make app/package name of artifacts available to users. This is needed to reliably install, patch and run apps built in test mode without inspecting the EAP or parsing the name of the EAP file.
- Replace the big-function interface with a builder style interface to make it easier to use with optional arguments and to decrease the probability of future additions being breaking changes. It is done in this commit since the API is broken anyway.
- Add artifact dir option to avoid duplicating the `copy_eaps` logic in `cargo-acap-sdk`. Duplication is not always bad but since Cargo is getting the same feature, it seems reasonable that our API which we want to be similar to Cargo's should get it too. Note that this used to be known as `--out-dir` in Cargo.

`crates/cargo-acap-build/src/lib.rs`:
- `execute` returns the path to the intermediate artifacts because it is not  possible to copy all artifacts to the same directory when more than one has the same name.

`crates/cargo-acap-sdk/README.md`:
- Add sample output from the help command to give potential users a preview of what to expect if they do install the program, without actually installing it. A secondary reason for documenting this is that it may help me visualize what changes I am planning to make by contrasting hypothetical, future help messages with the existing one.

`Makefile`:
- Bulk actions are added to make it easier to run all tests that require a device since I don't have a way to run those in CI.
- The pattern `*_*` currently matches exactly the apps because all have an underscore and no packages that is not an app has one.
- `licensekey` is the only non-app with tests designed to run on device.

`apps/consume_analytics_metadata/src/main.rs`:
- Increase the timeout to 10 because the first time the test runs after rebooting the test takes around 5 seconds, causing it to often fail. Tested on M4216 running 11.11.73.