### PR TITLE
feat(cargo-acap-sdk): Fetch target from device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger",
  "log",
+ "reqwest",
  "tokio",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,7 @@ name = "cargo-acap-sdk"
 version = "0.0.0"
 dependencies = [
  "acap-ssh-utils",
+ "acap-vapix",
  "anyhow",
  "cargo-acap-build",
  "clap",
@@ -376,6 +377,7 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger",
  "log",
+ "tokio",
  "url",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ check_build: $(patsubst %/,%/LICENSE,$(wildcard apps/*/))
 		-- \
 		--exclude acap-ssh-utils \
 		--exclude cargo-acap-build \
+		--exclude cargo-acap-sdk \
 		--exclude device-manager \
 		--workspace
 

--- a/crates/acap-vapix/src/apis/basic_device_info.rs
+++ b/crates/acap-vapix/src/apis/basic_device_info.rs
@@ -94,6 +94,10 @@ impl<'a> GetPropertiesRequest<'a> {
 }
 
 // TODO: Consider exposing a flat struct
+// Pros of flat:
+// - user does not need to know which substructure to look in; I tried
+//   `getAllUnrestrictedProperties` so this wasn't an issue but I did that because I didn't know
+//   the name of `architecture` and I was too lazy to look it up in the docs.
 #[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]

--- a/crates/cargo-acap-build/src/cargo_acap.rs
+++ b/crates/cargo-acap-build/src/cargo_acap.rs
@@ -170,7 +170,7 @@ fn exactly_one(
         manifest_file.exists(),
         out_file.as_ref().map(|f| f.exists()).unwrap_or(false),
     ) {
-        (false, false) => bail!("{file_name:?} exists neither {manifest_dir:?} nor {out_dir:?}"),
+        (false, false) => bail!("{file_name:?} exists neither in manifest dir {manifest_dir:?} nor in out dir {out_dir:?}"),
         (false, true) => Ok(out_file.expect("checked above")),
         (true, false) => Ok(manifest_file),
         (true, true) => bail!("{file_name:?} exist in both {manifest_dir:?} and {out_dir:?}"),

--- a/crates/cargo-acap-sdk/Cargo.toml
+++ b/crates/cargo-acap-sdk/Cargo.toml
@@ -10,6 +10,7 @@ clap_complete = "4.5.2"
 dirs = "5.0.1"
 env_logger = "0.11.1"
 log = "0.4.17"
+reqwest = {workspace = true, features = ["default-tls"]}
 tokio = { version = "1.36.0", features = ["full"] }
 url = "2.5.0"
 

--- a/crates/cargo-acap-sdk/Cargo.toml
+++ b/crates/cargo-acap-sdk/Cargo.toml
@@ -10,7 +10,9 @@ clap_complete = "4.5.2"
 dirs = "5.0.1"
 env_logger = "0.11.1"
 log = "0.4.17"
+tokio = { version = "1.36.0", features = ["full"] }
 url = "2.5.0"
 
 acap-ssh-utils = { path = "../acap-ssh-utils" }
+acap-vapix = { workspace = true }
 cargo-acap-build = { path = "../cargo-acap-build" }

--- a/crates/cargo-acap-sdk/src/commands/build_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/build_command.rs
@@ -1,18 +1,19 @@
 use cargo_acap_build::{get_cargo_metadata, AppBuilder, Architecture};
 use log::debug;
 
-use crate::{BuildOptions, ResolvedBuildOptions};
+use crate::ResolvedBuildOptions;
 
 #[derive(clap::Parser, Debug, Clone)]
 pub struct BuildCommand {
     #[command(flatten)]
-    build_options: BuildOptions,
+    build_options: ResolvedBuildOptions,
 }
 
 impl BuildCommand {
     pub fn exec(self) -> anyhow::Result<()> {
-        let Self { build_options } = self;
-        let ResolvedBuildOptions { target, mut args } = build_options.try_into()?;
+        let Self {
+            build_options: ResolvedBuildOptions { target, mut args },
+        } = self;
 
         if !args.iter().any(|arg| {
             arg.split('=')

--- a/crates/cargo-acap-sdk/src/commands/build_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/build_command.rs
@@ -1,7 +1,7 @@
 use cargo_acap_build::{get_cargo_metadata, AppBuilder, Architecture};
 use log::debug;
 
-use crate::BuildOptions;
+use crate::{BuildOptions, ResolvedBuildOptions};
 
 #[derive(clap::Parser, Debug, Clone)]
 pub struct BuildCommand {
@@ -11,9 +11,8 @@ pub struct BuildCommand {
 
 impl BuildCommand {
     pub fn exec(self) -> anyhow::Result<()> {
-        let Self {
-            build_options: BuildOptions { target, mut args },
-        } = self;
+        let Self { build_options } = self;
+        let ResolvedBuildOptions { target, mut args } = build_options.try_into()?;
 
         if !args.iter().any(|arg| {
             arg.split('=')

--- a/crates/cargo-acap-sdk/src/commands/install_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/install_command.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use cargo_acap_build::{AppBuilder, Architecture, Artifact};
 use log::debug;
 
-use crate::{command_utils::RunWith, ArchAbi, BuildOptions, DeployOptions};
+use crate::{command_utils::RunWith, ArchAbi, BuildOptions, DeployOptions, ResolvedBuildOptions};
 
 #[derive(clap::Parser, Debug, Clone)]
 pub struct InstallCommand {
@@ -15,11 +15,14 @@ pub struct InstallCommand {
 }
 
 impl InstallCommand {
-    pub fn exec(self) -> anyhow::Result<()> {
+    pub async fn exec(self) -> anyhow::Result<()> {
         let Self {
-            build_options: BuildOptions { target, mut args },
+            build_options,
             deploy_options,
         } = self;
+
+        let ResolvedBuildOptions { target, mut args } =
+            build_options.resolve(&deploy_options).await?;
 
         if !args.iter().any(|arg| {
             arg.split('=')

--- a/crates/cargo-acap-sdk/src/commands/test_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/test_command.rs
@@ -1,7 +1,7 @@
 use cargo_acap_build::{AppBuilder, Architecture, Artifact};
 use log::debug;
 
-use crate::{BuildOptions, DeployOptions};
+use crate::{BuildOptions, DeployOptions, ResolvedBuildOptions};
 
 #[derive(clap::Parser, Debug, Clone)]
 pub struct TestCommand {
@@ -12,20 +12,22 @@ pub struct TestCommand {
 }
 
 impl TestCommand {
-    pub fn exec(self) -> anyhow::Result<()> {
+    pub async fn exec(self) -> anyhow::Result<()> {
         let Self {
-            build_options:
-                BuildOptions {
-                    target,
-                    args: mut build_args,
-                },
-            deploy_options:
-                DeployOptions {
-                    host: address,
-                    user: username,
-                    pass: password,
-                },
+            build_options,
+            deploy_options,
         } = self;
+
+        let ResolvedBuildOptions {
+            target,
+            args: mut build_args,
+        } = build_options.resolve(&deploy_options).await?;
+
+        let DeployOptions {
+            host: address,
+            user: username,
+            pass: password,
+        } = deploy_options;
 
         build_args.push("--tests".to_string());
 

--- a/crates/cargo-acap-sdk/src/main.rs
+++ b/crates/cargo-acap-sdk/src/main.rs
@@ -111,10 +111,10 @@ struct DeployOptions {
 impl DeployOptions {
     pub async fn http_client(&self) -> anyhow::Result<HttpClient> {
         let Self { host, user, pass } = self;
-        Ok(HttpClient::from_host(host)
+        HttpClient::from_host(host)
             .await?
             .automatic_auth(user, pass)
-            .await?)
+            .await
     }
 }
 

--- a/crates/device-manager/src/restoration.rs
+++ b/crates/device-manager/src/restoration.rs
@@ -5,7 +5,7 @@ use acap_vapix::{systemready, HttpClient};
 use anyhow::bail;
 use log::{debug, info};
 use tokio::time::sleep;
-use url::{Host, Url};
+use url::Host;
 
 use crate::vapix::axis_cgi::firmwaremanagement1;
 
@@ -128,7 +128,7 @@ impl<'a> UptimeRestartDetector<'a> {
 
 pub async fn restore(host: &Host, user: &str, pass: &str) -> anyhow::Result<()> {
     info!("Restoring device...");
-    let mut client = HttpClient::new(Url::parse(&format!("http://{host}")).unwrap());
+    let mut client = HttpClient::from_host(host).await?;
     debug!("Checking if factory default is needed...");
     if systemready::systemready()
         .execute(&client)


### PR DESCRIPTION
This has two benefits:
- users don't need to remember or look up the architecture of the device being targeted.
- users don't have to specify the architecture. This is especially helpful when switching between devices frequently.

`crates/acap-vapix/src/apis/basic_device_info.rs`:
- Document my experience using the API to help me remember what to look out for when I address the TODO. It would probably be better to do this in an issue, but I think having a lot of issues could discourage potential contributors from interacting.

`crates/cargo-acap-build/src/cargo_acap.rs`:
- Add more context because learning that an expected file does not exist in `None` does not provide much information about how to resolve the problem.

`crates/cargo-acap-sdk/Cargo.toml`:
- Use same version of `tokio` as `device-manager`.
- Use `acap-vapix` from workspace because it is specified in the workspace manifest; I don't remember if there is a reason to not specify the others in a workspace manifest and I cannot be bothered digging it up.

`crates/cargo-acap-sdk/src/commands/build_command.rs`:
- Fetching of architecture is not implemented because I want the build command to continue being usable without having a device at hand, and I cannot immediately think of a way to make the device options optional without meaningfully increasing the complexity of the interface and the implementation.

`crates/cargo-acap-sdk/src/main.rs`:
- Assume basic auth because this is what `device-manager` currently sets up.
