### PR TITLE
chore: release cargo-acap-sdk 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "flate2",
  "log",
@@ -356,7 +356,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "home",
  "log",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-acap-sdk"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "acap-ssh-utils",
  "acap-vapix",
@@ -374,7 +374,7 @@ dependencies = [
  "cargo-acap-build",
  "clap",
  "clap_complete",
- "dirs",
+ "dirs 5.0.1",
  "env_logger",
  "log",
  "reqwest",
@@ -555,7 +555,7 @@ dependencies = [
  "acap-vapix",
  "anyhow",
  "clap",
- "dirs",
+ "dirs 3.0.2",
  "env_logger",
  "log",
  "regex",
@@ -603,11 +603,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/cargo-acap-sdk/Cargo.toml
+++ b/crates/cargo-acap-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-acap-sdk"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
I do this not because the state of the tool has crossed some threshold, but because it is being used and having versions makes it easier for users to install and it makes it easier to talk about which version is being used or when things change.

I do not plan to publish this version because I am still unsure about the name.