### PR TITLE
Alias cargo-acap-sdk and enable completions

### DIFF
--- a/.devhost/install-venv.sh
+++ b/.devhost/install-venv.sh
@@ -51,6 +51,8 @@ then
     echo "# Automatically created by install-venv.sh";
     echo ". ${VIRTUAL_ENV}/bin/activate";
     echo "unset -f deactivate";
+    echo 'cargo-acap-sdk completions $(basename $SHELL) | . /dev/stdin'
+    echo alias asdk=cargo-acap-sdk
     cat environment-setup.sh;
   } > "${INIT_ENV}"
 fi


### PR DESCRIPTION
This is easy to do, but it took me a long time to get around to it and I hope having it set out of the box will help others adopt the practice faster. For me, having it set automatically in new shells is a nice convenience.

On my system I have to type car^I-ac^I-s^I to complete `cargo-acap-sdk` which is rather annoying, asdk is both shorter and requires fewer finger movements on the keyboard.

`.devhost/install-venv.sh`:
- Using `$0` instead of `$(basename $SHELL)` seems easier, but it resolves to the name of the script being sourced, not the name of the current shell.