### PR TITLE
chore: use Rust implementation of mkhelp

### DIFF
--- a/.devhost/constraints.txt
+++ b/.devhost/constraints.txt
@@ -4,11 +4,7 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-fire==0.5.0
-    # via mkhelp
 jsonschema==3.2.0
-    # via -r .devhost/requirements.txt
-mkhelp==0.2
     # via -r .devhost/requirements.txt
 packaging==23.2
     # via build
@@ -19,11 +15,7 @@ pyproject-hooks==1.0.0
 pyrsistent==0.20.0
     # via jsonschema
 six==1.16.0
-    # via
-    #   fire
-    #   jsonschema
-termcolor==2.4.0
-    # via fire
+    # via jsonschema
 tomli==2.0.1
     # via
     #   build

--- a/.devhost/install-venv.sh
+++ b/.devhost/install-venv.sh
@@ -14,8 +14,6 @@ python3 -m venv "${VIRTUAL_ENV}"
 # As of writing this is needed because:
 # - the system version of `jsonschema` on Bookworm is 4.10.3, but the SDK uses 3.2.0, which
 #   presumably is incompatible.
-# - `mkhelp` is used to provide help texts for the `Makefile`. This would ideally be installed
-#   locally using `pipx` or ported to Rust where it can ship with its own lockfile.
 PIP_CONSTRAINT=constraints.txt pip install --requirement requirements.txt
 
 # Install `npm` into venv.
@@ -38,6 +36,7 @@ npm install -g @devcontainers/cli@0.65.0
 
 # Install rust programs
 cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target cargo-about@0.6.2
+cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target mkhelp@0.2.3
 cargo install --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/acap-ssh-utils
 cargo install --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/cargo-acap-build
 cargo install --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/device-manager

--- a/.devhost/requirements.txt
+++ b/.devhost/requirements.txt
@@ -1,4 +1,3 @@
 jsonschema ==3.2.0
-mkhelp
 pip
 pip-tools

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ EAP_INSTALL = cd $(CURDIR)/target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)/ \
 ## =====
 
 help:
-	@mkhelp print_docs $(firstword $(MAKEFILE_LIST)) help
+	@mkhelp $(firstword $(MAKEFILE_LIST))
 
 ## Reset <AXIS_DEVICE_IP> using password <AXIS_DEVICE_PASS> to a clean state suitable for development and testing.
 reinit:


### PR DESCRIPTION
Intended benefits include:
- Faster (`make help` goes from 80ms to 3ms)
- One step closer to having no Python dependencies (While it would be nice to remove the virtual environment I still think Python can have a place in Rust ACAP app development, especially for tests and misc. scripts).

One downside is that the Rust implementation is not compatible with my `kindly` program that provides enhanced tab completions for `Makefile`s, but I wasn't going to push that onto `acap-rs` users anyway.

I admit that the utility of this tool is pretty low, and it could probably be removed, but it gives me joy so as long as it does not get in the way for someone else I will keep it.
