### PR TITLE
chore: increase dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       default:
         applies-to: version-updates
@@ -21,4 +21,4 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Since the project does not host any applications that are deployed into exposed environments (the example apps are used as tests, and the other binary crates are development tools that typically don't listen on any ports, typically operate on trusted input or at least on a somewhat trustworthy network), I the downsides of frequent changes outweigh the benefits as I see it.

Benefits of weekly interval:
- Quicker response to potential security threats.

Benefits of monthly interval:
- Less maintenance.
- Better signal-to-noise ratio in the commit log.
