### PR TITLE
fix(cargo-acap-sdk)!: Use dev profile for install command

### DIFF
--- a/crates/acap-vapix/src/apis/applications_upload.rs
+++ b/crates/acap-vapix/src/apis/applications_upload.rs
@@ -123,13 +123,12 @@ impl<'a> UploadRequest<'a> {
             .post(PATH)
             .map_err(HttpRpcError::ParseUrl)?
             .replace_with(|b| {
-                dbg!(b
-                    .header(
-                        CONTENT_TYPE,
-                        "multipart/form-data; boundary=909c9a6bc15f00b579c6ceafa0daac3ec8989a59"
-                    )
-                    .header(CONTENT_LENGTH, form.len())
-                    .body(form))
+                b.header(
+                    CONTENT_TYPE,
+                    "multipart/form-data; boundary=909c9a6bc15f00b579c6ceafa0daac3ec8989a59",
+                )
+                .header(CONTENT_LENGTH, form.len())
+                .body(form)
             })
             .send()
             .await

--- a/crates/cargo-acap-sdk/src/commands/install_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/install_command.rs
@@ -19,18 +19,7 @@ impl InstallCommand {
             deploy_options,
         } = self;
 
-        let ResolvedBuildOptions { target, mut args } =
-            build_options.resolve(&deploy_options).await?;
-
-        if !args.iter().any(|arg| {
-            arg.split('=')
-                .next()
-                .expect("Split always yields at least one substring")
-                .starts_with("--profile")
-        }) {
-            debug!("Using release profile by default");
-            args.push("--profile=release".to_string());
-        }
+        let ResolvedBuildOptions { target, args } = build_options.resolve(&deploy_options).await?;
 
         let artifacts = AppBuilder::from_targets([Architecture::from(target)])
             .args(args)


### PR DESCRIPTION
The intended benefit is to speed up subsequent uses of the run command by building the same cache.

I find myself using the install command primarily to:
- perform the initial installation after checking out an app or re- initializing a device.
- perform a full installation because the manifest has changed.

In both cases I am likely to then use the run command, so any space savings on the device are uninteresting.

One remaining benefit is faster installation time, but for the uses outlined above the time savings from a shared cache are greater.

Before: 75
- install: 43 (28 build + 1 pack + 14 upload)
- run: 32 (21 build + 5 pack + 7 upload)

After: 70
- install: 59 (22 build + 5 pack + 31 upload)
- run: 11 (0 build + 5 pack + 7 upload)

(vapix_access built on i7-6700K and  installed on P8815-2)
