### PR TITLE
chore: Build apps with custom profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,12 @@ mdb-sys = { path = "crates/mdb-sys" }
 
 [workspace.package]
 edition = "2021"
+
+# For projects that build only apps it's probably easier to customize the releae profile.
+[profile.app]
+inherits = "release"
+opt-level = "s"
+strip = "symbols"
+lto = true
+panic = "abort"
+codegen-units = 1

--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,17 @@ reinit:
 
 ## Build <AXIS_PACKAGE> for <AXIS_DEVICE_ARCH>
 build: apps/$(AXIS_PACKAGE)/LICENSE
-	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE)
+	cargo-acap-build \
+		--target $(AXIS_DEVICE_ARCH) \
+		-- \
+		--package $(AXIS_PACKAGE) \
+		--profile app
 
 ## Install <AXIS_PACKAGE> on <AXIS_DEVICE_IP> using password <AXIS_DEVICE_PASS> and assuming architecture <AXIS_DEVICE_ARCH>
 install:
-	cargo-acap-sdk install
+	cargo-acap-sdk install \
+	-- \
+	--profile app
 
 ## Remove <AXIS_PACKAGE> from <AXIS_DEVICE_IP> using password <AXIS_DEVICE_PASS>
 remove:
@@ -115,7 +121,8 @@ install_all: $(patsubst %/,%/LICENSE,$(wildcard apps/*/))
 	cargo-acap-sdk install \
 		-- \
 		--package licensekey \
-		--package '*_*'
+		--package '*_*' \
+		--profile app
 
 ## Build and execute unit tests for all apps on <AXIS_DEVICE_IP> assuming architecture <AXIS_DEVICE_ARCH>
 test_all: $(patsubst %/,%/LICENSE,$(wildcard apps/*/))

--- a/crates/cargo-acap-sdk/src/commands/install_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/install_command.rs
@@ -45,6 +45,7 @@ impl InstallCommand {
                         .upload(path)?
                         .send()
                         .await?;
+                    debug!("Installed app {name}");
                 }
                 Artifact::Exe { path } => {
                     debug!("Skipping exe {path:?}");


### PR DESCRIPTION
The primary benefit is a smaller footprint on target; The total size of all EAP files as reported by `du` is:
- 15.0M before
-  4.4M after

The total size of all apps on target as reported by `du` is:
- 45.9M before
-  7.8M after

The free space on target as reported by `df` is:
- 24.8M before
-  6.7M after

(Tested with AXIS OS 11.11.73 on P8815-2)

I'm not entirely sure what to make of the discrepancy between the decreased footprint and the to a lesser extent increased free space; I suspect the compressed file system has something to do with it.

`Cargo.toml`:
- Customizing the release profile would be easier e.g. because that is the profile used by `cargo-acap-sdk install` by default. But since this project also hosts other binaries, such as `cargo-acap-sdk` I want to leave the release profile untouched in case it is needed for those.
- The profile used is one that I have seen in articles and projects; hopefully I'll get around to documenting in more detail the effects, good or bad, of each setting one day.

`Makefile`:
- Update the `build` verb to behave like `cargo-acap-sdk` because I want the UX to be similar to that program so that I get a feeling for it and any users of the `Makefile` can easily move to the dedicated program.
- `check_build` is not updated to use the new profile because it was not using the release profile previously. I don't think I have considered if this is optimal from a caching and testing perspective, but this is not the time to reevaluate that.

`crates/cargo-acap-sdk/src/commands/install_command.rs`:
- Log something when installation is done to make it possible to see in the logs how long the installation takes. This could probably be useful in other situations as well, such as to tell if the installation has completed or not.
