### PR TITLE
Add `Cargo.lock` to generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ check_format:
 .PHONY: check_format
 
 ## Check that generated files are up to date
-check_generated_files: $(patsubst %/,%/src/bindings.rs,$(wildcard crates/*-sys/))
+check_generated_files: Cargo.lock $(patsubst %/,%/src/bindings.rs,$(wildcard crates/*-sys/))
 	git update-index -q --refresh
 	git --no-pager diff --exit-code HEAD -- $^
 .PHONY: check_generated_files
@@ -248,6 +248,9 @@ fix_lint:
 
 ## Nouns
 ## =====
+
+Cargo.lock: FORCE
+	cargo metadata > /dev/null
 
 .devhost/constraints.txt: .devhost/requirements.txt
 	pip-compile \


### PR DESCRIPTION
Without this, updating `Cargo.lock` in a way that is incompatible with the manifest files would not cause CI to fail, despite the use of the `--locked` option.

My theory is that when `cargo-acap-build` is invoked, directly from the `Makefile` or indirectly via `cargo-acap-sdk`, it uses `cargo metadata` which updates the lockfile, causing later `cargo` invocations to succeed even when using the `--locked` option.

Disproved theories include:
- The `cargo install` commands in `install-venv.sh` update the lockfile (checking the diff immediately after this step reveals no diff)
- Some other action, prior to `make check_all` update the lockfile (checking the diff immediately before this step reveals no diff)

`Makefile`:
- Use `cargo metadata` because it reconciles the lockfile without updating packages as `cargo update` would, and faster and with fewer side effects than something like `cargo build`.
- Force the target to make sure it the lockfile is updated and the check works as intended, even if run before or without the other checks.