### PR TITLE
chore: release cargo-acap-sdk 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-acap-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "acap-ssh-utils",
  "acap-vapix",

--- a/crates/cargo-acap-sdk/Cargo.toml
+++ b/crates/cargo-acap-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-acap-sdk"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Changes since 0.1.0 include:
- Adds `start`, `restart`, `stop`, and `remove` commands that do what they say for the selected app(s).