### PR TITLE
Improve mdb

### DIFF
--- a/apps/consume_analytics_metadata/src/main.rs
+++ b/apps/consume_analytics_metadata/src/main.rs
@@ -1,7 +1,7 @@
 use std::{ffi::CStr, process::abort, thread::sleep, time::Duration};
 
 use log::{error, info};
-use mdb::{Connection, Subscriber, SubscriberConfig};
+use mdb::{error::BorrowedError, Connection, Message, Subscriber, SubscriberConfig};
 
 const TOPIC: &CStr = c"com.axis.analytics_scene_description.v0.beta";
 const SOURCE: &CStr = c"1";
@@ -9,34 +9,31 @@ const SOURCE: &CStr = c"1";
 fn main() {
     acap_logging::init_logger();
 
-    let connection = Connection::try_new(Some(Box::new(|e| {
+    let connection = Connection::try_new(Some(|e: BorrowedError| {
         error!("Not connected because {e:?}");
         abort();
-    })))
+    }))
     .unwrap();
 
     let config = SubscriberConfig::try_new(
         TOPIC,
         SOURCE,
-        Box::new(|message| {
+        |message: Message| {
             let payload = String::from_utf8_lossy(message.payload());
             let libc::timespec{ tv_sec, tv_nsec } = message.timestamp();
             info!("message received from topic: {TOPIC:?} on source: {SOURCE:?}: Monotonic time - {tv_sec}.{tv_nsec:0>9}. Data - {payload}");
-        }),
+        },
     )
     .unwrap();
-    let _subscriber = Subscriber::try_new(
-        &connection,
-        config,
-        Box::new(|e| match e {
+    let _subscriber =
+        Subscriber::try_new(&connection, config, |e: Option<BorrowedError>| match e {
             None => info!("Subscribed"),
             Some(e) => {
                 error!("Not subscribed because {e:?}");
                 abort();
             }
-        }),
-    )
-    .unwrap();
+        })
+        .unwrap();
 
     loop {
         sleep(Duration::from_secs(1));
@@ -54,34 +51,28 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::sync_channel(1);
         let mut droppable_tx = Some(tx);
 
-        let connection =
-            Connection::try_new(Some(Box::new(|e| println!("Not connected because {e:?}"))))
-                .unwrap();
-        let config = SubscriberConfig::try_new(
-            TOPIC,
-            SOURCE,
-            Box::new(move |message| {
-                let payload = String::from_utf8(message.payload().to_vec());
-                let Some(tx) = &droppable_tx else {
-                    debug!("Dropping message because sender was previously dropped");
-                    return;
-                };
-                if tx.try_send(payload).is_err() {
-                    warn!("Dropping sender because receiver has been deallocated");
-                    droppable_tx = None;
-                }
-            }),
-        )
+        let connection = Connection::try_new(Some(|e: BorrowedError| {
+            println!("Not connected because {e:?}")
+        }))
         .unwrap();
-        let _subscriber = Subscriber::try_new(
-            &connection,
-            config,
-            Box::new(|e| match e {
+        let config = SubscriberConfig::try_new(TOPIC, SOURCE, move |message: Message| {
+            let payload = String::from_utf8(message.payload().to_vec());
+            let Some(tx) = &droppable_tx else {
+                debug!("Dropping message because sender was previously dropped");
+                return;
+            };
+            if tx.try_send(payload).is_err() {
+                warn!("Dropping sender because receiver has been deallocated");
+                droppable_tx = None;
+            }
+        })
+        .unwrap();
+        let _subscriber =
+            Subscriber::try_new(&connection, config, |e: Option<BorrowedError>| match e {
                 None => println!("Subscribed"),
                 Some(e) => println!("Not subscribed because {e:?}"),
-            }),
-        )
-        .unwrap();
+            })
+            .unwrap();
 
         let payload = rx.recv_timeout(Duration::from_secs(10)).unwrap().unwrap();
         assert!(!payload.is_empty());

--- a/crates/mdb/src/error.rs
+++ b/crates/mdb/src/error.rs
@@ -1,0 +1,91 @@
+use std::ffi::{c_char, CStr};
+use std::fmt::{Debug, Display, Formatter};
+use std::marker::PhantomData;
+
+unsafe fn pchar_to_string(p_value: *const c_char) -> String {
+    assert!(!p_value.is_null());
+    let value = String::from(CStr::from_ptr(p_value).to_str().unwrap());
+    value
+}
+
+pub struct OwnedError {
+    ptr: *mut mdb_sys::mdb_error_t,
+}
+
+pub struct BorrowedError<'a> {
+    ptr: *const mdb_sys::mdb_error_t,
+    _marker: PhantomData<&'a mdb_sys::mdb_error_t>,
+}
+
+impl Debug for OwnedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Code: {}; Message: {:?};", self.code(), self.message())
+    }
+}
+
+impl Display for OwnedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.code(), self.message())
+    }
+}
+
+impl Debug for BorrowedError<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Code: {}; Message: {:?};", self.code(), self.message())
+    }
+}
+
+impl Display for BorrowedError<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.code(), self.message())
+    }
+}
+
+impl Drop for OwnedError {
+    fn drop(&mut self) {
+        unsafe {
+            mdb_sys::mdb_error_destroy(&mut self.ptr);
+        }
+    }
+}
+unsafe impl Send for OwnedError {}
+// Note that OwnedError is not Sync
+
+impl std::error::Error for OwnedError {}
+
+impl OwnedError {
+    pub(crate) fn new(ptr: *mut mdb_sys::mdb_error_t) -> Self {
+        OwnedError { ptr }
+    }
+
+    fn as_ref(&self) -> &mdb_sys::mdb_error_t {
+        unsafe { self.ptr.as_ref().unwrap() }
+    }
+
+    fn code(&self) -> i32 {
+        self.as_ref().code
+    }
+    fn message(&self) -> String {
+        unsafe { pchar_to_string(self.as_ref().message) }
+    }
+}
+
+impl BorrowedError<'_> {
+    pub(crate) fn new(ptr: *const mdb_sys::mdb_error_t) -> Self {
+        BorrowedError {
+            ptr,
+            _marker: PhantomData,
+        }
+    }
+
+    fn as_ref(&self) -> &mdb_sys::mdb_error_t {
+        unsafe { self.ptr.as_ref().unwrap() }
+    }
+
+    fn code(&self) -> i32 {
+        self.as_ref().code
+    }
+    fn message(&self) -> String {
+        unsafe { pchar_to_string(self.as_ref().message) }
+    }
+}

--- a/crates/mdb/src/lib.rs
+++ b/crates/mdb/src/lib.rs
@@ -1,5 +1,5 @@
 // TODO: Add documentation.
-use std::{any, ffi::CStr, slice::from_raw_parts};
+use std::{any, ffi::CStr, marker::PhantomData, slice::from_raw_parts};
 
 use libc::c_void;
 use log::{debug, error};
@@ -245,14 +245,17 @@ unsafe impl<'a> Send for Subscriber<'a> {}
 // implementation until it is needed or the Send and Sync properties are clearly guaranteed by
 // the C API.
 
-pub struct Message {
+pub struct Message<'a> {
     ptr: *const mdb_sys::mdb_message_t,
+    _marker: PhantomData<&'a mdb_sys::mdb_message_t>,
 }
 
-impl Message {
+impl Message<'_> {
     unsafe fn from_raw(ptr: *const mdb_sys::mdb_message_t) -> Self {
-        // TODO: Can we encode that this is never owned?
-        Self { ptr }
+        Self {
+            ptr,
+            _marker: PhantomData,
+        }
     }
     pub fn payload(&self) -> &[u8] {
         unsafe {


### PR DESCRIPTION
1. It doesn't make much sense to bundle OwnedOrBorrowedError when they serve different use cases, better split them into separate types.
2. Message borrows *const mdb_sys::mdb_message_t so should contain a marker with a lifetime bound.
3. The callbacks used in mdb are hidden behind pointers to pointers to DSTs when they could just be generic pointers. This also simplifies the UX since a consumer doesn't have to wrap callbacks in Box::new().

