### PR TITLE
chore: Track size of apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ check_generated_files: Cargo.lock $(patsubst %/,%/src/bindings.rs,$(wildcard cra
 ## Check that machine-dependent generated files are up to date
 ##
 ## Remember to fist build the apps and to make both targets in the dev-container.
-check_generated_files_container: apps-$(AXIS_DEVICE_ARCH).checksum
+check_generated_files_container: apps-$(AXIS_DEVICE_ARCH).checksum apps-$(AXIS_DEVICE_ARCH).filesize
 	git update-index -q --refresh
 	git --no-pager diff --exit-code HEAD -- $^
 .PHONY: check_generated_files_container
@@ -289,6 +289,9 @@ apps/%/LICENSE: apps/%/Cargo.toml about.hbs
 
 apps-$(AXIS_DEVICE_ARCH).checksum: $(sort $(wildcard target/acap/*_$(AXIS_DEVICE_ARCH).eap))
 	shasum $^ > $@
+
+apps-$(AXIS_DEVICE_ARCH).filesize: $(sort $(wildcard target/acap/*_$(AXIS_DEVICE_ARCH).eap))
+	du $^ > $@
 
 crates/%-sys/src/bindings.rs: FORCE
 	cp $(firstword $(wildcard target/*/*/build/$*-sys-*/out/bindings.rs)) $@

--- a/apps-aarch64.filesize
+++ b/apps-aarch64.filesize
@@ -1,0 +1,10 @@
+5808	target/acap/bounding_box_example_0_0_0_aarch64.eap
+5676	target/acap/consume_analytics_metadata_0_0_0_aarch64.eap
+860	target/acap/embedded_web_page_0_0_0_aarch64.eap
+5596	target/acap/hello_world_0_0_0_aarch64.eap
+5676	target/acap/inspect_env_0_0_0_aarch64.eap
+5648	target/acap/licensekey_handler_0_0_0_aarch64.eap
+13968	target/acap/reverse_proxy_0_0_0_aarch64.eap
+7636	target/acap/send_event_1_0_0_aarch64.eap
+860	target/acap/using_a_build_script_0_0_0_aarch64.eap
+14916	target/acap/vapix_access_0_0_0_aarch64.eap


### PR DESCRIPTION
Because this is an important property and we want to make sure that the size actually decreases when we make improvements and that it does not inadvertently increase.

The total size of all apps can be reported like:
```console
$ cat apps-aarch64.filesize | cut -f1 | paste -sd+ | bc
66644
```

Using `--profile app` would make the size smaller and, arguably, more representative but it would also require us to change what we build so it is skipped for now:
```console
$ cat apps-aarch64.filesize | cut -f1 | paste -sd+ | bc
4676
```

`Makefile`:
- Don't use the `--total` option to reduce the risk of merge conflicts.
- Don't use the `--human-readable` option to make it easier to sum the numbers afterwards.