### PR TITLE
fix(acap-ssh-utils): Warn users that commands may break

### DIFF
--- a/crates/acap-ssh-utils/src/main.rs
+++ b/crates/acap-ssh-utils/src/main.rs
@@ -14,6 +14,12 @@ use url::Host;
 /// - enabled SSH on the device,
 /// - configured the SSH user with a password and the necessary permissions, and
 /// - installed any apps that will be impersonated.
+///
+/// # Warning
+///
+/// Neither the ability to patch an already installed app using SSH nor to run an installed app
+/// with stdout attached to the terminal are officially supported use cases. As such all commands
+/// provided by this program may stop working on future versions AXIS OS.
 #[derive(Clone, Debug, Parser)]
 #[clap(verbatim_doc_comment)]
 struct Cli {


### PR DESCRIPTION
With this change the help text becomes:

```console
$ acap-ssh-utils help
Utilities for interacting with Axis devices over SSH.

The commands assume that the user has already
- installed `scp`, `ssh` and `sshpass`,
- added the device to the `known_hosts` file,
- enabled SSH on the device,
- configured the SSH user with a password and the necessary permissions, and
- installed any apps that will be impersonated.

# Warning

Neither the ability to patch an already installed app using SSH nor to run an installed app
with stdout attached to the terminal are officially supported use cases. As such all commands
provided by this program may stop working on future versions AXIS OS.

Usage: acap-ssh-utils --host <HOST> --user <USER> --pass <PASS> <COMMAND>

Commands:
  patch      Patch app on device
  run-app    Run app on device, sending output to the terminal
  run-other  Run any executable on device, sending output to the terminal
  help       Print this message or the help of the given subcommand(s)

Options:
      --host <HOST>
          Hostname or IP address of the device
          
          [env: AXIS_DEVICE_IP=]

  -u, --user <USER>
          The username to use for the ssh connection
          
          [env: AXIS_DEVICE_USER=]

  -p, --pass <PASS>
          The password to use for the ssh connection
          
          [env: AXIS_DEVICE_PASS=]

  -h, --help
          Print help (see a summary with '-h')
```