### PR TITLE
feat(device-manager): Allow unsigned ACAPs

### DIFF
--- a/crates/device-manager/src/initialization.rs
+++ b/crates/device-manager/src/initialization.rs
@@ -173,5 +173,11 @@ pub async fn initialize(host: Host, pass: &str) -> anyhow::Result<HttpClient> {
         .arg(&format!("root@{}", host));
     log_stdout(sshpass)?;
 
+    info!("Allowing unsigned ACAPs...");
+    client
+        .get("/axis-cgi/applications/config.cgi?action=set&name=AllowUnsigned&value=true")?
+        .send()
+        .await?;
+
     Ok(client)
 }

--- a/crates/device-manager/src/initialization.rs
+++ b/crates/device-manager/src/initialization.rs
@@ -7,7 +7,6 @@ use std::{
 use acap_vapix::{parameter_management, systemready, HttpClient};
 use anyhow::Context;
 use log::{debug, info};
-use reqwest::StatusCode;
 use tokio::time::sleep;
 use url::{Host, Url};
 


### PR DESCRIPTION
For development, it is not feasible to sign the ACAP for every iteration.

Allow unsigned ACAPs as part of the initialization process.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
