### PR TITLE
Don't install the `devcontainer` program by default

### DIFF
--- a/.devhost/install-devcontainer.sh
+++ b/.devhost/install-devcontainer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eux
+
+# Install `npm` into venv.
+# As of writing this is needed because `devcontainer` is a convenient way to test dev containers
+# automatically.
+curl \
+  --location \
+  --output /tmp/node-v18.16.1-linux-x64.tar.gz \
+  "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-x64.tar.gz"
+
+echo "59582f51570d0857de6333620323bdeee5ae36107318f86ce5eca24747cabf5b /tmp/node-v18.16.1-linux-x64.tar.gz" \
+| sha256sum -c -
+
+tar -xf "/tmp/node-v18.16.1-linux-x64.tar.gz" --strip-components 1 -C "${VIRTUAL_ENV}"
+
+rm /tmp/node-v18.16.1-linux-x64.tar.gz
+
+# Install `devcontainer` into venv
+npm install -g @devcontainers/cli@0.65.0

--- a/.devhost/install-venv.sh
+++ b/.devhost/install-venv.sh
@@ -16,24 +16,6 @@ python3 -m venv "${VIRTUAL_ENV}"
 #   presumably is incompatible.
 PIP_CONSTRAINT=constraints.txt pip install --requirement requirements.txt
 
-# Install `npm` into venv.
-# As of writing this is needed because `devcontainer` is a convenient way to test dev containers
-# automatically.
-curl \
-  --location \
-  --output /tmp/node-v18.16.1-linux-x64.tar.gz \
-  "https://nodejs.org/dist/v18.16.1/node-v18.16.1-linux-x64.tar.gz"
-
-echo "59582f51570d0857de6333620323bdeee5ae36107318f86ce5eca24747cabf5b /tmp/node-v18.16.1-linux-x64.tar.gz" \
-| sha256sum -c -
-
-tar -xf "/tmp/node-v18.16.1-linux-x64.tar.gz" --strip-components 1 -C "${VIRTUAL_ENV}"
-
-rm /tmp/node-v18.16.1-linux-x64.tar.gz
-
-# Install `devcontainer` into venv
-npm install -g @devcontainers/cli@0.65.0
-
 # Install rust programs
 cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target cargo-about@0.6.2
 cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target mkhelp@0.2.3


### PR DESCRIPTION
The method I used for installing `npm` was flaky and a common source of false positives in CI. Since it is not needed in CI, and it is needed locally only when not using the recommended dev container based environment, not installing it by default seems like a cost effective remedy.

The steps to install it are still kept to make it easier to reproduce my development environment. It expects that a `venv` is already `source`d but does not eagerly verify this. Since it doesn't look like it has any bad side effects and the script will be used only rarely and is not easily discoverable this feels like a worthwhile trade-off.