### PR TITLE
feat!(cargo-acap-build): Make the release profile the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ stop:
 ## * The device has SSH enabled the ssh user root configured.
 run: apps/$(AXIS_PACKAGE)/LICENSE
 	CARGO_TARGET_DIR=target-$(AXIS_DEVICE_ARCH) \
-	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE)
+	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE) --profile dev
 	acap-ssh-utils patch target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)/*.eap
 	acap-ssh-utils run-app \
 		--environment RUST_LOG=debug \
@@ -110,7 +110,7 @@ test: apps/$(AXIS_PACKAGE)/LICENSE
 	# The `scp` command below needs the wildcard to match exactly one file.
 	rm -r target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)-*/$(AXIS_PACKAGE) ||:
 	CARGO_TARGET_DIR=target-$(AXIS_DEVICE_ARCH) \
-	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE) --tests
+	cargo-acap-build --target $(AXIS_DEVICE_ARCH) -- -p $(AXIS_PACKAGE) --profile dev --tests
 	acap-ssh-utils patch target/$(AXIS_DEVICE_ARCH)/$(AXIS_PACKAGE)-*/*.eap
 	acap-ssh-utils run-app \
 		--environment RUST_LOG=debug \
@@ -270,6 +270,7 @@ target-$(AXIS_DEVICE_ARCH)/acap/_envoy: $(patsubst %/,%/LICENSE,$(wildcard apps/
 		--target $(AXIS_DEVICE_ARCH) \
 		-- \
 		--package '*_*' \
+		--profile dev \
 		--locked
 	touch $@
 

--- a/crates/cargo-acap-build/src/main.rs
+++ b/crates/cargo-acap-build/src/main.rs
@@ -23,7 +23,11 @@ impl From<ArchAbi> for Architecture {
     }
 }
 
-/// ACAP analog to `cargo build`.
+/// Build app using cargo
+///
+/// Some defaults deviate from Cargo:
+/// - Builds for all supported targets instead of host.
+/// - Uses the release profile instead of the dev profile.
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -50,8 +54,19 @@ impl Cli {
 }
 
 fn build_and_copy(cli: Cli) -> anyhow::Result<()> {
+    let mut args = cli.args.clone();
+    if !args.iter().any(|arg| {
+        arg.split('=')
+            .next()
+            .expect("Split always yields at least one substring")
+            .starts_with("--profile")
+    }) {
+        debug!("Using release profile by default");
+        args.push("--profile=release".to_string());
+    }
+
     AppBuilder::from_targets(cli.targets())
-        .args(cli.args)
+        .args(args)
         .artifact_dir(get_cargo_metadata()?.target_directory.join("acap"))
         .execute()?;
     Ok(())


### PR DESCRIPTION
Since `cargo-acap-sdk` is the preferred tool for local development it should be relatively rare for people to use `cargo-acap-build` locally. As such it makes sense to optimize it for the continuous integration where I expect it will be used relatively frequently.

This decision rests on the assumption that there are few cases when a developer would be better server by `cargo-acap-build` for local development compared to `cargo-acap-sdk build`.

`Makefile`:
- Update targets to do the same as they did before.

`crates/cargo-acap-build/src/main.rs`:
- The pattern for overriding the profile is taken from `cargo-acap-sdk`.