### PR TITLE
chore: Document pitfall with reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,10 @@ check_generated_files: Cargo.lock $(patsubst %/,%/src/bindings.rs,$(wildcard cra
 .PHONY: check_generated_files
 
 ## Check that generated files are up to date, including machine-dependent generated files.
+##
+## Note that this will likely work only if:
+## - The command is run inside the dev container.
+## - The name of the repository root is `acap-rs` because this affects the path inside the container.
 check_generated_files_container: apps-$(AXIS_DEVICE_ARCH).checksum apps-$(AXIS_DEVICE_ARCH).filesize
 	git update-index -q --refresh
 	git --no-pager diff --exit-code HEAD -- $^


### PR DESCRIPTION
It took me a while to figure out that the reason my builds were failing on my renamed fork was because the working directory changed with the name of the repository. I hope that documenting these pitfalls will save time for others who might otherwise encounter and be confused by the same problems.

A couple of factors caused this to be especially confusing for me:
- The commit I was testing also affected the checksums.
- I was troubleshooting both on a renamed fork and a fork with the original name.