### PR TITLE
feat: Include commit id in version reported by CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "cli-version",
  "dirs",
  "env_logger",
  "flate2",
@@ -412,6 +413,7 @@ dependencies = [
  "acap-build",
  "anyhow",
  "clap",
+ "cli-version",
  "dirs",
  "env_logger",
  "log",
@@ -429,6 +431,7 @@ dependencies = [
  "cargo-acap-build",
  "clap",
  "clap_complete",
+ "cli-version",
  "dirs",
  "env_logger",
  "log",
@@ -533,6 +536,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
+name = "cli-version"
+version = "0.1.0"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +621,7 @@ dependencies = [
  "acap-vapix",
  "anyhow",
  "clap",
+ "cli-version",
  "dirs",
  "env_logger",
  "log",
@@ -783,6 +791,7 @@ dependencies = [
  "acap-vapix",
  "anyhow",
  "clap",
+ "cli-version",
  "device-manager",
  "dirs",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.2"
 
-acap-build = {path="crates/acap-build"}
+acap-build = { path = "crates/acap-build" }
 acap-logging = { path = "crates/acap-logging" }
 acap-ssh-utils = { path = "crates/acap-ssh-utils" }
 acap-vapix = { path = "crates/acap-vapix" }
@@ -52,6 +52,7 @@ axstorage-sys = { path = "crates/axstorage-sys" }
 bbox = { path = "crates/bbox" }
 bbox-sys = { path = "crates/bbox-sys" }
 cargo-acap-build = { path = "crates/cargo-acap-build" }
+cli-version = { path = "crates/cli-version" }
 device-manager = { path = "crates/device-manager" }
 licensekey = { path = "crates/licensekey" }
 licensekey-sys = { path = "crates/licensekey-sys" }

--- a/crates/acap-ssh-utils/Cargo.toml
+++ b/crates/acap-ssh-utils/Cargo.toml
@@ -15,3 +15,5 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 url = { workspace = true }
 tar = { workspace = true }
+
+cli-version = { workspace = true }

--- a/crates/acap-ssh-utils/src/main.rs
+++ b/crates/acap-ssh-utils/src/main.rs
@@ -4,6 +4,7 @@ use std::{env, fs::File, path::PathBuf};
 use acap_ssh_utils::{patch_package, run_other, run_package};
 use anyhow::Context;
 use clap::{Parser, Subcommand};
+use cli_version::version_with_commit_id;
 use log::debug;
 use url::Host;
 
@@ -22,7 +23,7 @@ use url::Host;
 /// with stdout attached to the terminal are officially supported use cases. As such all commands
 /// provided by this program may stop working on future versions AXIS OS.
 #[derive(Clone, Debug, Parser)]
-#[clap(verbatim_doc_comment, version)]
+#[clap(verbatim_doc_comment, version = version_with_commit_id!())]
 struct Cli {
     #[command(flatten)]
     netloc: Netloc,

--- a/crates/cargo-acap-build/Cargo.toml
+++ b/crates/cargo-acap-build/Cargo.toml
@@ -13,3 +13,4 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 acap-build = { workspace = true }
+cli-version = { workspace = true }

--- a/crates/cargo-acap-build/src/main.rs
+++ b/crates/cargo-acap-build/src/main.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 
 use cargo_acap_build::{get_cargo_metadata, AppBuilder, Architecture};
 use clap::{Parser, ValueEnum};
+use cli_version::version_with_commit_id;
 use log::debug;
 
 // TODO: Figure out what to call this.
@@ -29,7 +30,7 @@ impl From<ArchAbi> for Architecture {
 /// - Builds for all supported targets instead of host.
 /// - Uses the release profile instead of the dev profile.
 #[derive(Parser)]
-#[clap(verbatim_doc_comment, version)]
+#[clap(verbatim_doc_comment, version = version_with_commit_id!())]
 struct Cli {
     /// If given, build only for the given architecture(s).
     ///

--- a/crates/cargo-acap-sdk/Cargo.toml
+++ b/crates/cargo-acap-sdk/Cargo.toml
@@ -17,3 +17,4 @@ url = { workspace = true }
 acap-ssh-utils = { workspace = true }
 acap-vapix = { workspace = true }
 cargo-acap-build = { workspace = true }
+cli-version = { workspace = true }

--- a/crates/cargo-acap-sdk/src/main.rs
+++ b/crates/cargo-acap-sdk/src/main.rs
@@ -4,6 +4,7 @@ use std::{ffi::OsString, fs::File, str::FromStr};
 use acap_vapix::{applications_control, basic_device_info, HttpClient};
 use cargo_acap_build::Architecture;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use cli_version::version_with_commit_id;
 use log::debug;
 use url::Host;
 
@@ -17,7 +18,7 @@ mod commands;
 
 /// Tools for developing ACAP apps using Rust
 #[derive(Parser)]
-#[clap(verbatim_doc_comment, version)]
+#[clap(verbatim_doc_comment, version = version_with_commit_id!())]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/crates/cli-version/Cargo.toml
+++ b/crates/cli-version/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cli-version"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+proc-macro = true

--- a/crates/cli-version/src/lib.rs
+++ b/crates/cli-version/src/lib.rs
@@ -1,0 +1,33 @@
+extern crate proc_macro;
+use std::{env, process::Command};
+
+use proc_macro::TokenStream;
+
+fn commit_id() -> Option<String> {
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(
+        std::str::from_utf8(&output.stdout)
+            .unwrap()
+            .trim()
+            .to_owned(),
+    )
+}
+
+fn version() -> Option<String> {
+    env::var("CARGO_PKG_VERSION").ok()
+}
+
+/// Return a version for use in CLIs as a string literal
+#[proc_macro]
+pub fn version_with_commit_id(_item: TokenStream) -> TokenStream {
+    let version = version().unwrap_or("unknown version".to_owned());
+    let commit_id = commit_id().unwrap_or("unknown commit id".to_string());
+    format!(r#""{version} ({commit_id})""#).parse().unwrap()
+}

--- a/crates/device-manager/Cargo.toml
+++ b/crates/device-manager/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
 
 acap-vapix = { workspace = true }
+cli-version = { workspace = true }

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -2,13 +2,14 @@
 use std::{env, fs::File};
 
 use clap::{Parser, Subcommand};
+use cli_version::version_with_commit_id;
 use device_manager::{initialize, restore};
 use log::{debug, info};
 use url::Host;
 
 /// Utilities for managing individual devices.
 #[derive(Clone, Debug, Parser)]
-#[clap(verbatim_doc_comment, version)]
+#[clap(verbatim_doc_comment, version = version_with_commit_id!())]
 struct Cli {
     #[command(flatten)]
     netloc: Netloc,

--- a/crates/fleet-manager/Cargo.toml
+++ b/crates/fleet-manager/Cargo.toml
@@ -17,3 +17,4 @@ url = { workspace = true, features = ["serde"] }
 
 device-manager = { workspace = true }
 acap-vapix = { workspace = true }
+cli-version = { workspace = true }

--- a/crates/fleet-manager/src/main.rs
+++ b/crates/fleet-manager/src/main.rs
@@ -3,6 +3,7 @@ use std::{ffi::OsString, path::PathBuf};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
+use cli_version::version_with_commit_id;
 use tracing::debug;
 
 use crate::commands::{
@@ -17,7 +18,7 @@ mod database;
 
 /// Utilities for managing devices in bulk.
 #[derive(Debug, Parser)]
-#[clap(verbatim_doc_comment, version)]
+#[clap(verbatim_doc_comment, version = version_with_commit_id!())]
 struct Cli {
     /// Location of database file.
     fleet: Option<PathBuf>,


### PR DESCRIPTION
The goal is to make it possible for users to communicate what version
of the programs they are using when they experience issues.

`crates/cli-version/src/lib.rs`:
- Never fail because I want to avoid new users first experience being that the tools fail to install at all costs.