### PR TITLE
fix(acap-build): Add `--build=no-build` option

### DIFF
--- a/crates/acap-build/src/bin/acap-build.rs
+++ b/crates/acap-build/src/bin/acap-build.rs
@@ -10,6 +10,7 @@ use std::{
 use acap_build::{AppBuilder, Architecture};
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
+use log::debug;
 use tempdir::TempDir;
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, ValueEnum)]
@@ -17,12 +18,14 @@ use tempdir::TempDir;
 enum BuildOption {
     #[default]
     Make,
+    NoBuild,
 }
 
 impl Display for BuildOption {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Make => write!(f, "make"),
+            Self::NoBuild => write!(f, "no-build"),
         }
     }
 }
@@ -54,6 +57,9 @@ fn main() -> anyhow::Result<()> {
             .status()
             .context("subprocess make failed")?
             .success()),
+        BuildOption::NoBuild => {
+            debug!("no build");
+        }
     }
 
     let arch: Architecture = env::var("OECORE_TARGET_ARCH")?.parse()?;


### PR DESCRIPTION
This is needed to build the apps in `acap-native-sdk-examples`. With this change all the examples except for one can be reproduced: `openssl_curl_example` cannot be reproduced but that is probably only because `libcrypto.so` is not reproducible.