### PR TITLE
fix(cargo-acap-build): Name test binaries correctly

### DIFF
--- a/crates/cargo-acap-build/src/cargo_acap.rs
+++ b/crates/cargo-acap-build/src/cargo_acap.rs
@@ -134,7 +134,7 @@ fn pack(
 
     debug!("Creating app builder");
     let mut app_builder = AppBuilder::new(false, &staging_dir, &manifest, arch)?;
-    app_builder.add(&executable)?;
+    app_builder.add_exe(&executable)?;
 
     // TODO: Consider providing defaults for more files.
     // TODO: Consider providing a default build script instead to enable users to opt out entirely.


### PR DESCRIPTION
The renaming of test binaries to the file name expected by `acap-build` was accidentally removed in #139.
