### PR TITLE
chore: Merge some `RUN` steps in `Dockerfile`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,35 +40,26 @@ COPY .devhost/install-system-packages.sh ./
 RUN ./install-system-packages.sh \
  && rm install-system-packages.sh
 
-ENV PATH=/usr/local/cargo/bin:$PATH \
+ENV PATH=/usr/local/venv/bin:/usr/local/cargo/bin:$PATH \
     CARGO_HOME=/usr/local/cargo \
-    RUSTUP_HOME=/usr/local/rustup
-
-COPY .devhost/install-rust.sh ./
-RUN  ./install-rust.sh \
- && chmod a+w -R $CARGO_HOME $RUSTUP_HOME \
- && rm install-rust.sh
-
-COPY rust-toolchain.toml ./
-RUN rustup show \
- && rm rust-toolchain.toml
-
-ENV PATH=/usr/local/venv/bin:$PATH \
+    RUSTUP_HOME=/usr/local/rustup \
     VIRTUAL_ENV=/usr/local/venv
-
-RUN --mount=type=bind,target=/context \
-    cd /context/.devhost \
- && ./install-venv.sh $VIRTUAL_ENV \
- && chmod a+w -R $VIRTUAL_ENV
 
 # If neither `CARGO_HOME` nor `HOME` is set when launching a container, then cargo will try to
 # download crates to this directory. If launched with the `--user` option then this will fail.
 # TODO: Replace the example in the README with something that does not mount any volumes.
-RUN mkdir /.cargo \
- && chmod a+w /.cargo/
 
-# `install-venv.sh` install a rust package which creates the cargo registry directory as root.
+# When installing Rust binaries the source is downloaded to `$CARGO_HOME/registry`.
+# It is over 400M already, but since the same dependencies will be required in CI, this may be an advantage.
 # TODO: Consider removing the content of `CARGO_HOME` instead of `chmod`ing it;
-# it is over 400M already, but that for now having that cached at the start of the dev container may be an advantage.
-RUN find $CARGO_HOME $RUSTUP_HOME -type d -exec chmod a+rwx {} +
-RUN find $CARGO_HOME $RUSTUP_HOME -type f -exec chmod a+rw {} +
+
+RUN --mount=type=bind,target=/context\
+    cd /context/.devhost \
+ &&  ./install-rust.sh \
+ && rustup show \
+ && ./install-venv.sh $VIRTUAL_ENV \
+ && chmod a+w -R $VIRTUAL_ENV \
+ && mkdir /.cargo \
+ && chmod a+w /.cargo/ \
+ && find $CARGO_HOME $RUSTUP_HOME -type d -exec chmod a+rwx {} + \
+ && find $CARGO_HOME $RUSTUP_HOME -type f -exec chmod a+rw {} +


### PR DESCRIPTION
This reduces the size of the final image from 6.3G to 4.4G it speeds it up by about 1 minute in CI (probably even mor on my Ubuntu 22.04 machine where the `chmod` step takes about 5 minutes).

The main improvement comes from not populating `CARGO_HOME` and `RUSTUP_HOME, and `chmod`ing them in separate steps since this caused the files to be included in two layers; the rust toolchain is particularly expensive at over 1G.
