### PR TITLE
Use `bash` instead of `sh` to enable use of -v comparison operation.

### DIFF
--- a/bin/remote-test.sh
+++ b/bin/remote-test.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 
-if [ -n "${AXIS_DEVICE_IP}" ]; then
+if [ -v AXIS_DEVICE_IP ]; then
     LOCAL_PATH="$1"
     shift
 

--- a/bin/remote-test.sh
+++ b/bin/remote-test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -eu
 
-if [ -v AXIS_DEVICE_IP ]; then
+if [ ${AXIS_DEVICE_IP:-} ]; then
     LOCAL_PATH="$1"
     shift
 


### PR DESCRIPTION
### Describe your changes

Use `#!/bin/bash` instead of `#!/bin/sh` to enable use of `-v` option for checking of `AXIS_DEVICE_IP` is set.

### Issue ticket number and link

- Fixes #165

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
