### PR TITLE
feat: Add device discovery tool

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,6 @@
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {}
     },
-    "remoteUser": "${localEnv:USER}"
+    "remoteUser": "${localEnv:USER}",
+    "runArgs": ["--network=host"]
 }

--- a/.devhost/install-venv.sh
+++ b/.devhost/install-venv.sh
@@ -23,6 +23,7 @@ cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../
 cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/cargo-acap-build
 cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/cargo-acap-sdk
 cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target --path ../crates/device-manager
+cargo install --locked --root ${VIRTUAL_ENV} --target-dir /tmp/target --git https://github.com/apljungquist/rs4a.git --branch plain-mdns
 
 rm -r /tmp/target
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,12 @@ build:
 		--package $(AXIS_PACKAGE) \
 		--profile app
 
+## Discover Axis devices on the local network
+##
+## Note that this does not work inside a container unless it's running on a Linux host.
+discover-devices:
+	rs4a discover-devices
+
 ## Install <AXIS_PACKAGE> on <AXIS_DEVICE_IP> using password <AXIS_DEVICE_PASS> and assuming architecture <AXIS_DEVICE_ARCH>
 install:
 	cargo-acap-sdk install \


### PR DESCRIPTION
To make it easier finding the address of development devices connected to the local network but not directly to the workstation.