### PR TITLE
chore: Link to article "Managing the size of Rust binaries"

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ by this project.
 
 - [Related projects](docs/related-projects.md)
 - [Running apps and tests on device](docs/running-apps-and-tests-on-device.md)
+- [Managing the size of Rust binaries](https://github.com/apljungquist/managing-the-size-of-rust-binaries)
 
 ## Troubleshooting
 


### PR DESCRIPTION
The large size of Rust binaries is a well known problem and search engines will readily return many results on the topic, not least the excellent min-sized-rust. However, none of these results focus specifically on use cases that are similar to ACAP apps; the three clusters I have observed are:
- code golf: impressive yet impractical exercises in making toy programs as small as possible.
- embedded: true embedded systems with hard limits on space on the order of hundreds of kilobytes.
- WASM