### PR TITLE
chore: Pin nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,3 +21,5 @@ jobs:
         run: devcontainer exec --remote-env ACAP_BUILD_IMPL=equivalent --workspace-folder . make check_generated_files_container
       - name: Run other checks
         run: devcontainer exec --workspace-folder . make check_other
+      - name: Run miri check
+        run: devcontainer exec --workspace-folder . make check_miri

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,5 +21,3 @@ jobs:
         run: devcontainer exec --remote-env ACAP_BUILD_IMPL=equivalent --workspace-folder . make check_generated_files_container
       - name: Run other checks
         run: devcontainer exec --workspace-folder . make check_other
-      - name: Run miri check
-        run: devcontainer exec --workspace-folder . make check_miri

--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,8 @@ check_lint:
 
 ## Check that risky FFI patterns are sound using miri
 check_miri:
-	rustup +nightly component add miri
-	cargo +nightly miri test \
+	rustup +nightly-2025-04-18 component add miri
+	cargo +nightly-2025-04-18 miri test \
 		--package ffi_patterns \
 		--target aarch64-unknown-linux-gnu \
 		--target thumbv7neon-unknown-linux-gnueabihf


### PR DESCRIPTION
Because `check_miri` started failing:

>    Doc-tests ffi_patterns
> fatal error: cross-interpreting doctests is not currently supported by Miri.
> error: doctest failed, to rerun pass `-p ffi_patterns --doc`

This seems to work for now, but I have a vague memory of pinned nightlies stopping working for me in the past. If this happens we should consider disabling the failing test in CI.