### PR TITLE
Update build command in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Once it completes there should be `.eap` files in `target/acap`:
 $ ls -1 target/acap
 hello_world_0_0_0_aarch64.eap
 hello_world_0_0_0_armv7hf.eap
-
 ```
 
 This works with any of the [example applications](#example-applications).

--- a/README.md
+++ b/README.md
@@ -36,12 +36,14 @@ The recommended setup is using the [dev container](#dev-container) and the most 
 ### Dev container
 
 The quickest way to build the `hello_world` example is to launch the dev container and
-run `make build AXIS_PACKAGE=hello_world`.
-Once it completes there should be an `.eap` file in `target/acap`:
+run `cargo-acap-build -- -p hello_world`.
+Once it completes there should be `.eap` files in `target/acap`:
 
 ```console
 $ ls -1 target/acap
-hello_world_1_0_0_aarch64.eap
+hello_world_0_0_0_aarch64.eap
+hello_world_0_0_0_armv7hf.eap
+
 ```
 
 This works with any of the [example applications](#example-applications).


### PR DESCRIPTION
The command _"$ cargo-acap-build -- -p hello_world"_ builds EAPs for both architectures which is useful since developers might use different devices and don't need to modify the build command for their specific setup.  I have also noticed that it takes less time(approximately 1 sec less) than '_make build AXIS_PACKAGE=hello_world'_. 