### PR TITLE
feat(acap-ssh-utils): Add option to override the SSH port.

### DIFF
--- a/crates/acap-ssh-utils/src/lib.rs
+++ b/crates/acap-ssh-utils/src/lib.rs
@@ -31,16 +31,31 @@ fn sshpass(pass: &str, program: &str) -> std::process::Command {
     cmd
 }
 
-fn scp(src: &Path, user: &str, pass: &str, host: &Host, tgt: &str) -> std::process::Command {
+fn scp(
+    src: &Path,
+    user: &str,
+    pass: &str,
+    host: &Host,
+    port: Option<u16>,
+    tgt: &str,
+) -> std::process::Command {
     let mut cmd = sshpass(pass, "scp");
+    if let Some(port) = port {
+        // Note that scp uses an uppercase P while ssh uses a lowercase P.
+        cmd.arg("-P").arg(port.to_string());
+    }
     cmd.arg("-p"); // Ensure temporary files become executable.
     cmd.arg(src);
     cmd.arg(format!("{user}@{host}:{tgt}"));
     cmd
 }
 
-fn ssh(user: &str, pass: &str, host: &Host) -> std::process::Command {
+fn ssh(user: &str, pass: &str, host: &Host, port: Option<u16>) -> std::process::Command {
     let mut cmd = sshpass(pass, "ssh");
+    if let Some(port) = port {
+        // Note that scp uses an uppercase P while ssh uses a lowercase P.
+        cmd.arg("-p").arg(port.to_string());
+    }
     cmd.arg("-x"); // Makes no difference when I have tested but seems to be the right thing to do.
     cmd.arg(format!("{user}@{host}"));
     cmd
@@ -117,11 +132,11 @@ struct RemoteTemporaryFile {
 }
 
 impl RemoteTemporaryFile {
-    fn try_new(user: &str, pass: &str, host: &Host) -> anyhow::Result<Self> {
-        let mut ssh_mktemp = ssh(user, pass, host);
+    fn try_new(user: &str, pass: &str, host: &Host, port: Option<u16>) -> anyhow::Result<Self> {
+        let mut ssh_mktemp = ssh(user, pass, host, port);
         ssh_mktemp.arg("mktemp");
         let path = ssh_mktemp.run_with_captured_stdout()?.trim().to_string();
-        let mut ssh_rm = ssh(user, pass, host);
+        let mut ssh_rm = ssh(user, pass, host, port);
         ssh_rm.arg("rm");
         ssh_rm.arg(&path);
         Ok(Self {
@@ -156,18 +171,19 @@ pub fn run_other(
     user: &str,
     pass: &str,
     host: &Host,
+    port: Option<u16>,
     env: HashMap<&str, &str>,
     args: &[&str],
 ) -> anyhow::Result<()> {
-    let temp_file = RemoteTemporaryFile::try_new(user, pass, host)?;
+    let temp_file = RemoteTemporaryFile::try_new(user, pass, host, port)?;
 
-    scp(prog, user, pass, host, &temp_file.path).run_with_logged_stdout()?;
+    scp(prog, user, pass, host, port, &temp_file.path).run_with_logged_stdout()?;
 
     let mut exec = std::process::Command::new(&temp_file.path);
     exec.envs(env);
     exec.args(args);
 
-    let mut ssh_exec = ssh(user, pass, host);
+    let mut ssh_exec = ssh(user, pass, host, port);
     ssh_exec.arg(format!("{exec:?}"));
     ssh_exec.run_with_inherited_stdout()?;
 
@@ -192,6 +208,7 @@ pub fn run_package(
     user: &str,
     pass: &str,
     host: &Host,
+    port: Option<u16>,
     package: &str,
     env: HashMap<&str, &str>,
     args: &[&str],
@@ -220,7 +237,7 @@ pub fn run_package(
 
     // TODO: Consider giving user control over what happens with stdout when running concurrently.
     // The escaping of quotation marks is ridiculous, but it's automatic and empirically verifiable.
-    let mut ssh_exec_as_package = ssh(user, pass, host);
+    let mut ssh_exec_as_package = ssh(user, pass, host, port);
     ssh_exec_as_package.arg(format!("{cd:?} && {exec_as_package:?}"));
     ssh_exec_as_package.run_with_inherited_stdout()?;
     Ok(())
@@ -237,7 +254,13 @@ pub fn run_package(
 /// - configured the SSH user with a password and the necessary permissions,
 /// - installed the app, and
 /// - stopped the app, if it was running.
-pub fn patch_package(package: &Path, user: &str, pass: &str, host: &Host) -> anyhow::Result<()> {
+pub fn patch_package(
+    package: &Path,
+    user: &str,
+    pass: &str,
+    host: &Host,
+    port: Option<u16>,
+) -> anyhow::Result<()> {
     // Not all files can be replaced, so we upload only the ones that can.
     // This archive will hold the files that will be uploded.
     let mut partial = tar::Builder::new(Vec::new());
@@ -268,7 +291,7 @@ pub fn patch_package(package: &Path, user: &str, pass: &str, host: &Host) -> any
     // Currently the error when an app is not installed is not very helpful:
     // tar: can't change directory to '/usr/local/packages/<APP_NAME>': No such file or directory
     // TODO: Better error when application is not installed
-    let mut ssh_tar = ssh(user, pass, host);
+    let mut ssh_tar = ssh(user, pass, host, port);
     ssh_tar.args(["tar", "-xvC", package_dir.to_str().unwrap()]);
 
     ssh_tar.stdin(Stdio::piped());

--- a/crates/acap-ssh-utils/src/main.rs
+++ b/crates/acap-ssh-utils/src/main.rs
@@ -47,6 +47,9 @@ struct Netloc {
     /// Hostname or IP address of the device.
     #[arg(long, value_parser = url::Host::parse, env="AXIS_DEVICE_IP")]
     host: Host,
+    /// Override the default port.
+    #[clap(long, env = "AXIS_DEVICE_SSH_PORT")]
+    port: Option<u16>,
     /// The username to use for the ssh connection.
     #[clap(short, long, env = "AXIS_DEVICE_USER", default_value = "root")]
     user: String,
@@ -73,7 +76,13 @@ struct Patch {
 
 impl Patch {
     fn exec(self, netloc: Netloc) -> anyhow::Result<()> {
-        patch_package(&self.package, &netloc.user, &netloc.pass, &netloc.host)
+        patch_package(
+            &self.package,
+            &netloc.user,
+            &netloc.pass,
+            &netloc.host,
+            netloc.port,
+        )
     }
 }
 
@@ -97,6 +106,7 @@ impl RunApp {
             &netloc.user,
             &netloc.pass,
             &netloc.host,
+            netloc.port,
             &self.package,
             self.environment
                 .iter()
@@ -128,6 +138,7 @@ impl RunOther {
             &netloc.user,
             &netloc.pass,
             &netloc.host,
+            netloc.port,
             self.environment
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))

--- a/crates/cargo-acap-sdk/src/commands/run_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/run_command.rs
@@ -24,6 +24,7 @@ impl RunCommand {
             host: address,
             http_port: _,
             https_port: _,
+            ssh_port,
             user: username,
             pass: password,
         } = deploy_options;
@@ -39,16 +40,32 @@ impl RunCommand {
                 Artifact::Eap { path, name } => {
                     // TODO: Install instead of patch when needed
                     debug!("Patching app {name}");
-                    acap_ssh_utils::patch_package(&path, &username, &password, &address)?;
+                    acap_ssh_utils::patch_package(&path, &username, &password, &address, ssh_port)?;
                     debug!("Running app {name}");
-                    acap_ssh_utils::run_package(&username, &password, &address, &name, envs, &[])?
+                    acap_ssh_utils::run_package(
+                        &username,
+                        &password,
+                        &address,
+                        ssh_port,
+                        &name,
+                        envs,
+                        &[],
+                    )?
                 }
                 Artifact::Exe { path } => {
                     debug!(
                         "Running exe {}",
                         path.file_name().unwrap().to_string_lossy()
                     );
-                    acap_ssh_utils::run_other(&path, &username, &password, &address, envs, &[])?;
+                    acap_ssh_utils::run_other(
+                        &path,
+                        &username,
+                        &password,
+                        &address,
+                        ssh_port,
+                        envs,
+                        &[],
+                    )?;
                 }
             }
         }

--- a/crates/cargo-acap-sdk/src/commands/test_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/test_command.rs
@@ -27,6 +27,7 @@ impl TestCommand {
             host: address,
             http_port: _,
             https_port: _,
+            ssh_port,
             user: username,
             pass: password,
         } = deploy_options;
@@ -47,10 +48,10 @@ impl TestCommand {
                 Artifact::Eap { path, name } => {
                     // TODO: Install instead of patch when needed
                     debug!("Patching app {name}");
-                    acap_ssh_utils::patch_package(&path, &username, &password, &address)?;
+                    acap_ssh_utils::patch_package(&path, &username, &password, &address, ssh_port)?;
                     debug!("Running app {name}");
                     acap_ssh_utils::run_package(
-                        &username, &password, &address, &name, envs, &test_args,
+                        &username, &password, &address, ssh_port, &name, envs, &test_args,
                     )?
                 }
                 Artifact::Exe { path } => {
@@ -59,7 +60,7 @@ impl TestCommand {
                         path.file_name().unwrap().to_string_lossy()
                     );
                     acap_ssh_utils::run_other(
-                        &path, &username, &password, &address, envs, &test_args,
+                        &path, &username, &password, &address, ssh_port, envs, &test_args,
                     )?;
                 }
             }

--- a/crates/cargo-acap-sdk/src/main.rs
+++ b/crates/cargo-acap-sdk/src/main.rs
@@ -116,7 +116,10 @@ struct DeployOptions {
     /// Override the default port for HTTPS.
     #[clap(long, env = "AXIS_DEVICE_HTTPS_PORT")]
     https_port: Option<u16>,
-    /// Username of SSH- and/or VAPIX-account to authenticate as.
+    /// Override the default port for SSH.
+    #[clap(long, env = "AXIS_DEVICE_SSH_PORT")]
+    ssh_port: Option<u16>,
+    /// Username of VAPIX-account to authenticate as.
     ///
     /// It is up to the user to ensure that these have been created on the device as needed.
     #[clap(long, env = "AXIS_DEVICE_USER", default_value = "root")]
@@ -141,6 +144,7 @@ impl DeployOptions {
             host,
             http_port,
             https_port,
+            ssh_port: _,
             user,
             pass,
         } = self;


### PR DESCRIPTION
This is needed to use the run and test commands from `cargo-acap-sdk` with the Virtual Loan Tool which employs port mapping to make multiple cameras available at one (or possibly a small number) of IP addresses.
