### PR TITLE
chore: Add `/.git/` to the container build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !/.devhost/
+!/.git/
 !/Cargo.lock
 !/Cargo.toml
 !/about.hbs


### PR DESCRIPTION
Without it the `version_with_commit_id` macro cannot infer what commit the developer tools are installed from. The purpose of having this information is "to make it possible for users to communicate what version of the programs they are using when they experience issues" (#137).

Drawback of adding the git directory to the container build context include:
- Worse cache performance (if memory serves any file changes to the mounted tree will invalidate that step in the dockerfile). But since this is the last step and I don't usually rebuild the dev container unless I expect something to be different, I don't think this will be an issue.
- The resulting environment could in theory be the function of information not in the current commit or one of its ancestors. The likelihood and impact of this are both low and I think the benefit of the improved troubleshooting far outweighs the risk.
