### PR TITLE
fix(*): Treat MacOS on ARM as host, not target

### DIFF
--- a/apps/bounding_box_example/src/main.rs
+++ b/apps/bounding_box_example/src/main.rs
@@ -127,7 +127,7 @@ fn main() {
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use std::sync::{atomic::AtomicBool, Arc};

--- a/apps/embedded_web_page/src/main.rs
+++ b/apps/embedded_web_page/src/main.rs
@@ -8,7 +8,7 @@ fn main() {}
 // TODO: Figure out how to resolve paths on host
 // It is not particularly interesting for this app, but once the reverse proxy example is added it
 // becomes feasible to serve the embedded web page also when testing on host.
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use std::{env, path::PathBuf};

--- a/apps/inspect_env/src/main.rs
+++ b/apps/inspect_env/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     info!("stderr is terminal: {}", std::io::stderr().is_terminal());
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use std::{env, path::PathBuf};

--- a/apps/reverse_proxy/src/main.rs
+++ b/apps/reverse_proxy/src/main.rs
@@ -97,7 +97,7 @@ fn new_app() -> Router {
     // does not depend on the C APIs and could be built without the SDK. If that is done one a
     // host other than x86_64 this will be erroneously excluded.
     // TODO: Find a more robust configuration
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_os = "macos"))]
     let app = {
         use tower_http::services::ServeDir;
         app.nest_service(

--- a/apps/using_a_build_script/src/main.rs
+++ b/apps/using_a_build_script/src/main.rs
@@ -9,7 +9,7 @@ fn main() {}
 // TODO: Figure out how to resolve paths on host
 // It is not particularly interesting for this app, but once the reverse proxy example is added it
 // becomes feasible to serve the embedded web page also when testing on host.
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use std::{env, path::PathBuf};

--- a/apps/vapix_access/src/main.rs
+++ b/apps/vapix_access/src/main.rs
@@ -28,7 +28,7 @@ async fn main() {
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use acap_vapix::{

--- a/crates/axevent-sys/build.rs
+++ b/crates/axevent-sys/build.rs
@@ -18,7 +18,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/axevent-sys/src/lib.rs
+++ b/crates/axevent-sys/src/lib.rs
@@ -11,8 +11,8 @@ type gdouble = ::std::os::raw::c_double;
 type gint = ::std::os::raw::c_int;
 type guint = ::std::os::raw::c_uint;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("bindings.rs");

--- a/crates/axoverlay-sys/build.rs
+++ b/crates/axoverlay-sys/build.rs
@@ -18,7 +18,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/axoverlay-sys/src/lib.rs
+++ b/crates/axoverlay-sys/src/lib.rs
@@ -10,8 +10,8 @@ type guchar = ::std::os::raw::c_uchar;
 type gfloat = ::std::os::raw::c_float;
 type gint = ::std::os::raw::c_int;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("bindings.rs");

--- a/crates/axparameter-sys/build.rs
+++ b/crates/axparameter-sys/build.rs
@@ -28,7 +28,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/axparameter-sys/src/lib.rs
+++ b/crates/axparameter-sys/src/lib.rs
@@ -7,10 +7,10 @@ use glib_sys::{gboolean, gpointer, GError, GList, GQuark};
 
 type gchar = ::std::os::raw::c_char;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("bindings.rs");
 
 // Due to an issue specified in https://github.com/rust-lang/rust-bindgen/issues/1966

--- a/crates/axstorage-sys/build.rs
+++ b/crates/axstorage-sys/build.rs
@@ -18,7 +18,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/axstorage-sys/src/lib.rs
+++ b/crates/axstorage-sys/src/lib.rs
@@ -12,8 +12,8 @@ pub type gdouble = ::std::os::raw::c_double;
 pub type gint = ::std::os::raw::c_int;
 pub type guint = ::std::os::raw::c_uint;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("bindings.rs");

--- a/crates/bbox-sys/build.rs
+++ b/crates/bbox-sys/build.rs
@@ -18,7 +18,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/bbox-sys/src/lib.rs
+++ b/crates/bbox-sys/src/lib.rs
@@ -4,8 +4,8 @@
 #![allow(improper_ctypes)]
 #![allow(clippy::useless_transmute)]
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("bindings.rs");

--- a/crates/larod-sys/build.rs
+++ b/crates/larod-sys/build.rs
@@ -22,7 +22,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/larod-sys/src/lib.rs
+++ b/crates/larod-sys/src/lib.rs
@@ -2,8 +2,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("bindings.rs");

--- a/crates/licensekey-sys/build.rs
+++ b/crates/licensekey-sys/build.rs
@@ -17,7 +17,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/licensekey-sys/src/lib.rs
+++ b/crates/licensekey-sys/src/lib.rs
@@ -3,8 +3,8 @@
 #![allow(non_snake_case)]
 #![allow(improper_ctypes)]
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("./bindings.rs");

--- a/crates/licensekey/src/flex.rs
+++ b/crates/licensekey/src/flex.rs
@@ -173,7 +173,7 @@ pub fn licensekey_get_state_string(state_code: c_int) -> Option<CStringPtr> {
     }
 }
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 #[cfg(test)]
 mod tests {
     use std::ffi::CString;

--- a/crates/mdb-sys/build.rs
+++ b/crates/mdb-sys/build.rs
@@ -19,7 +19,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/mdb-sys/src/lib.rs
+++ b/crates/mdb-sys/src/lib.rs
@@ -5,8 +5,8 @@
 
 pub use libc::timespec;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("./bindings.rs");

--- a/crates/vdo-sys/build.rs
+++ b/crates/vdo-sys/build.rs
@@ -24,7 +24,9 @@ fn populated_bindings(dst: &path::PathBuf) {
 
 fn main() {
     let dst = path::PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64" {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "x86_64"
+        && env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "macos"
+    {
         populated_bindings(&dst);
     }
 }

--- a/crates/vdo-sys/src/lib.rs
+++ b/crates/vdo-sys/src/lib.rs
@@ -27,8 +27,8 @@ type guint64 = u64;
 type gsize = usize;
 type gssize = isize;
 
-#[cfg(not(target_arch = "x86_64"))]
+#[cfg(not(any(target_arch = "x86_64", target_os = "macos")))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_os = "macos"))]
 include!("bindings.rs");


### PR DESCRIPTION
This improves the experience of working on the project, and any project that depends on the binding crates, on an Apple computer with apple silicon. Getting the bindings to compile is still difficult, but this allows running `cargo check` on host. It may also be necessary to enable working on the other packages on host, but I have not explicitly tested that.

The implementation to this commit does not solve the root problem; if someone is trying to develop of an ARM based computer it is unlikely that we will be able to use the `target_*` keys to classify that as host. But in terms of classification it is a strict improvement over status quo.