### PR TITLE
fix(challenge_build_tools): Use valid parameter name

### DIFF
--- a/apps-aarch64.checksum
+++ b/apps-aarch64.checksum
@@ -1,4 +1,4 @@
-2307f06b6728658c1e0d6d9251e3fbd22f209b9d  target-aarch64/acap/Challenge_Build_Tools_1_0_0_all.eap
+8fff02275de11d5f3aba0e4aba4ab162a489200c  target-aarch64/acap/Challenge_Build_Tools_1_0_0_all.eap
 a21721df06c91115d99f718353586ee8eaa0356e  target-aarch64/acap/axoverlay_example_0_0_0_aarch64.eap
 bfc22269e9bf53b6a2526009413e0e8c281b3d5b  target-aarch64/acap/axparameter_example_0_0_0_aarch64.eap
 ff26e764367290e803fbe96f32d2f89c613aad30  target-aarch64/acap/axstorage_example_0_0_0_aarch64.eap

--- a/apps/challenge_build_tools/manifest.json
+++ b/apps/challenge_build_tools/manifest.json
@@ -43,7 +43,7 @@
       ],
       "paramConfig": [
         {
-          "name": "my-parameter",
+          "name": "MyParameterWith1KindaTrickyName_",
           "default": "yes",
           "type": "bool:no,yes"
         }


### PR DESCRIPTION
I'm not sure if this parameter ever worked, but it does not as of 12.5.56. These are the rules for a valid parameter name:

- Match the regex `[A-Za-z][A-Za-z0-9_]*`
- Have length no more than 32 characters.

The new name is exactly 32 characters and uses all the allowed characters.

Tested on AXIS OS 12.5.56 running on an AXIS M1075-L Box Camera:
- The application can be installed without triggering any errors.
