### PR TITLE
feat(using-a-build-script): Use `CARGO_PKG_*` environment variables

### DIFF
--- a/apps/using_a_build_script/build.rs
+++ b/apps/using_a_build_script/build.rs
@@ -67,10 +67,10 @@ fn generate_manifest(out_dir: &Path) {
         "schemaVersion": "1.2",
         "acapPackageConf": {
             "setup": {
-                "appName": "using_a_build_script",
+                "appName": env!("CARGO_PKG_NAME"),
                 "vendor": "Axis Communications",
                 "runMode": "never",
-                "version": "0.0.0"
+                "version": env!("CARGO_PKG_VERSION")
             },
             "configuration": {
                 "settingPage": "index.html"


### PR DESCRIPTION
This is convenient, especially for the version which changes a lot and must be kept in sync [^1]. Doing so manually is tedious and error prone.

This also helps demonstrate the potential of the build script integration in `cargo-acap-build`.

[^1]: crates/cargo-acap-build/README.md