### PR TITLE
feat(larod): Add safe Rust bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "larod"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "expect-test",
+ "larod-sys",
+ "libc",
+ "log",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "larod-sys"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ bbox = { path = "crates/bbox" }
 bbox-sys = { path = "crates/bbox-sys" }
 cargo-acap-build = { path = "crates/cargo-acap-build" }
 cli-version = { path = "crates/cli-version" }
+larod = { path = "crates/larod" }
 larod-sys = { path = "crates/larod-sys" }
 licensekey = { path = "crates/licensekey" }
 licensekey-sys = { path = "crates/licensekey-sys" }

--- a/crates/larod/Cargo.toml
+++ b/crates/larod/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "larod"
+version = "0.0.0"
+edition.workspace = true
+license = "MIT"
+description = "Safe Rust bindings for the Larod (ML Inference) API"
+
+[dependencies]
+larod-sys = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+device-tests = []
+
+[dev-dependencies]
+anyhow = { workspace = true }
+env_logger = { workspace = true }
+expect-test = { workspace = true }

--- a/crates/larod/src/connection.rs
+++ b/crates/larod/src/connection.rs
@@ -1,0 +1,282 @@
+use std::ffi::CStr;
+use std::os::raw::c_int;
+
+use crate::device::Device;
+use crate::model::Model;
+use crate::tensor::Tensors;
+use crate::{Error, Map};
+
+pub use larod_sys::larodAccess;
+
+/// A connection to the larod inference daemon.
+///
+/// This is the root object for all larod operations. Devices, models,
+/// tensors, and job requests are all created through or associated with
+/// a connection.
+///
+/// The connection is closed when dropped.
+pub struct Connection {
+    pub(crate) raw: *mut larod_sys::larodConnection,
+}
+
+impl Connection {
+    /// Connect to the larod daemon.
+    pub fn try_new() -> Result<Self, Error> {
+        let mut raw: *mut larod_sys::larodConnection = std::ptr::null_mut();
+        let (success, maybe_error) = unsafe { try_func!(larod_sys::larodConnect, &mut raw) };
+        if !success {
+            return Err(maybe_error.unwrap_or(Error::MissingError));
+        }
+        if raw.is_null() {
+            return Err(Error::NullPointer);
+        }
+        debug_assert!(maybe_error.is_none());
+        Ok(Self { raw })
+    }
+
+    /// Returns the number of active sessions on the larod daemon.
+    pub fn num_sessions(&self) -> Result<u64, Error> {
+        let mut num: u64 = 0;
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetNumSessions, self.raw, &mut num) };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(num)
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    /// List all available inference devices.
+    ///
+    /// The returned devices borrow from this connection and become invalid
+    /// when the connection is dropped.
+    pub fn devices(&self) -> Result<Vec<Device<'_>>, Error> {
+        let mut num_devices: usize = 0;
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodListDevices, self.raw, &mut num_devices,) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+
+        let raw_ptrs: Vec<*const larod_sys::larodDevice> =
+            (0..num_devices).map(|i| unsafe { *ptr.add(i) }).collect();
+
+        let devices = raw_ptrs
+            .into_iter()
+            .map(Device::from_raw)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(devices)
+    }
+
+    /// Get a specific device by name and instance number.
+    pub fn device(&self, name: &CStr, instance: u32) -> Result<Device<'_>, Error> {
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodGetDevice,
+                self.raw as *const _,
+                name.as_ptr(),
+                instance,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Device::from_raw(ptr)
+    }
+
+    /// Load a model from a file descriptor.
+    ///
+    /// # Arguments
+    ///
+    /// * `fd` - File descriptor of the model file (e.g. from `File::as_raw_fd()`)
+    /// * `device` - The inference device to use
+    /// * `access` - Access mode (private or public)
+    /// * `name` - Optional human-readable name for the model
+    /// * `params` - Optional parameters map
+    pub fn load_model(
+        &self,
+        fd: c_int,
+        device: &Device<'_>,
+        access: larodAccess,
+        name: Option<&CStr>,
+        params: Option<&Map>,
+    ) -> Result<Model, Error> {
+        let name_ptr = name.map_or(std::ptr::null(), |n| n.as_ptr());
+        let params_ptr = params.map_or(std::ptr::null(), |p| p.as_ptr());
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodLoadModel,
+                self.raw,
+                fd,
+                device.as_ptr(),
+                access,
+                name_ptr,
+                params_ptr,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Model::from_raw(ptr)
+    }
+
+    /// Retrieve a model by its server-assigned ID.
+    ///
+    /// This can be used to obtain a handle to a public model loaded by another session.
+    /// The returned model is an owned handle (`*mut larodModel`) that will be
+    /// destroyed via `larodDestroyModel` on drop.
+    pub fn get_model(&self, model_id: u64) -> Result<Model, Error> {
+        let (ptr, maybe_error) = unsafe { try_func!(larod_sys::larodGetModel, self.raw, model_id) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Model::from_raw(ptr)
+    }
+
+    /// List all models visible to this session (own private + all public models).
+    ///
+    /// Each model in the returned Vec is an owned handle. The C API returns
+    /// `*mut *mut larodModel` (mutable inner pointers, unlike `larodListDevices`
+    /// which returns `*const` inner pointers), indicating caller ownership.
+    pub fn models(&self) -> Result<Vec<Model>, Error> {
+        let mut num_models: usize = 0;
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetModels, self.raw, &mut num_models) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+
+        let models = ModelListGuard {
+            raw: ptr,
+            len: num_models,
+        };
+        let mut ids = Vec::with_capacity(num_models);
+        for i in 0..num_models {
+            let raw = unsafe { *models.raw.add(i) };
+            if raw.is_null() {
+                return Err(Error::NullPointer);
+            }
+            let (id, maybe_error) =
+                unsafe { try_func!(larod_sys::larodGetModelId, raw as *const _) };
+            if let Some(err) = maybe_error {
+                return Err(err);
+            }
+            ids.push(id);
+        }
+        drop(models);
+
+        ids.into_iter().map(|id| self.get_model(id)).collect()
+    }
+
+    /// Create tensor descriptors for a model's inputs, with backing memory
+    /// allocated by the larod daemon.
+    ///
+    /// Use [`crate::FD_TYPE_DMA`], [`crate::FD_TYPE_DISK`], or a combination of
+    /// `FD_PROP_*` constants for `fd_prop_flags`.
+    pub fn alloc_model_inputs(
+        &self,
+        model: &Model,
+        fd_prop_flags: u32,
+        params: Option<&Map>,
+    ) -> Result<Tensors<'_>, Error> {
+        let mut num_tensors: usize = 0;
+        // C API takes *mut larodMap even for read-only access.
+        let params_ptr = params.map_or(std::ptr::null_mut(), |p| p.as_ptr());
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodAllocModelInputs,
+                self.raw,
+                model.as_ptr(),
+                fd_prop_flags,
+                &mut num_tensors,
+                params_ptr,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Tensors::from_raw(ptr, num_tensors, self)
+    }
+
+    /// Create tensor descriptors for a model's outputs, with backing memory
+    /// allocated by the larod daemon.
+    ///
+    /// Use [`crate::FD_TYPE_DMA`], [`crate::FD_TYPE_DISK`], or a combination of
+    /// `FD_PROP_*` constants for `fd_prop_flags`.
+    pub fn alloc_model_outputs(
+        &self,
+        model: &Model,
+        fd_prop_flags: u32,
+        params: Option<&Map>,
+    ) -> Result<Tensors<'_>, Error> {
+        let mut num_tensors: usize = 0;
+        let params_ptr = params.map_or(std::ptr::null_mut(), |p| p.as_ptr());
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodAllocModelOutputs,
+                self.raw,
+                model.as_ptr(),
+                fd_prop_flags,
+                &mut num_tensors,
+                params_ptr,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Tensors::from_raw(ptr, num_tensors, self)
+    }
+}
+
+impl std::fmt::Debug for Connection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Connection")
+            .field("raw", &self.raw)
+            .finish()
+    }
+}
+
+// SAFETY: We hold exclusive ownership of the raw pointer and the larod
+// daemon connection does not require access from a specific thread.
+unsafe impl Send for Connection {}
+
+// Connection is intentionally !Sync — the larod daemon connection is not
+// safe for concurrent access from multiple threads.
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // larodDisconnect takes *mut *mut and nulls the pointer. Returns bool + error.
+        let mut error: *mut larod_sys::larodError = std::ptr::null_mut();
+        let success = unsafe { larod_sys::larodDisconnect(&mut self.raw, &mut error) };
+        // Always free the error if set, even on success, to avoid leaking.
+        if !error.is_null() {
+            // SAFETY: error is non-null and allocated by larodDisconnect.
+            let err = unsafe { crate::LarodError::from_raw(error) };
+            if !success {
+                log::error!("Failed to disconnect from larod: {err}");
+            }
+        } else if !success {
+            log::error!("Failed to disconnect from larod (no error details)");
+        }
+    }
+}
+
+struct ModelListGuard {
+    raw: *mut *mut larod_sys::larodModel,
+    len: usize,
+}
+
+impl Drop for ModelListGuard {
+    fn drop(&mut self) {
+        unsafe { larod_sys::larodDestroyModels(&mut self.raw, self.len) }
+    }
+}

--- a/crates/larod/src/device.rs
+++ b/crates/larod/src/device.rs
@@ -1,0 +1,66 @@
+use std::ffi::CStr;
+use std::marker::PhantomData;
+
+use crate::Error;
+
+/// A hardware inference device (e.g. NPU, GPU, CPU).
+///
+/// Devices are borrowed from a [`Connection`](crate::Connection) and become
+/// invalid when the connection is dropped. They cannot be individually freed.
+pub struct Device<'conn> {
+    raw: *const larod_sys::larodDevice,
+    // Use *const to suppress auto-Sync (raw pointers are !Sync).
+    _conn: PhantomData<&'conn *const ()>,
+}
+
+impl<'conn> Device<'conn> {
+    pub(crate) fn from_raw(raw: *const larod_sys::larodDevice) -> Result<Self, Error> {
+        if raw.is_null() {
+            return Err(Error::NullPointer);
+        }
+        Ok(Self {
+            raw,
+            _conn: PhantomData,
+        })
+    }
+
+    /// Returns the device name (e.g. "cpu-tflite", "artpec8-dlpu-tflite").
+    pub fn name(&self) -> Result<&CStr, Error> {
+        let (ptr, maybe_error) = unsafe { try_func!(larod_sys::larodGetDeviceName, self.raw) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        // SAFETY: ptr is non-null and points into the device's internal storage.
+        // Lifetime is tied to the connection via 'conn.
+        Ok(unsafe { CStr::from_ptr(ptr) })
+    }
+
+    /// Returns the device instance number.
+    pub fn instance(&self) -> Result<u32, Error> {
+        let mut instance: u32 = 0;
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetDeviceInstance, self.raw, &mut instance,) };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(instance)
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *const larod_sys::larodDevice {
+        self.raw
+    }
+}
+
+impl std::fmt::Debug for Device<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Device").field("raw", &self.raw).finish()
+    }
+}
+
+// SAFETY: Device is a borrowed read-only pointer into connection-internal storage.
+// Moving the Device to another thread is safe as long as the connection outlives it
+// (enforced by the 'conn lifetime).
+unsafe impl Send for Device<'_> {}

--- a/crates/larod/src/error.rs
+++ b/crates/larod/src/error.rs
@@ -1,0 +1,148 @@
+use std::ffi::CStr;
+use std::fmt::{Debug, Display};
+
+pub use larod_sys::larodErrorCode;
+
+/// Calls a larod C function that takes `*mut *mut larodError` as its last argument.
+/// Returns `(result, Option<Error>)`.
+///
+/// # Safety
+///
+/// The caller must ensure the function pointer and all arguments are valid.
+/// The macro initializes the error pointer to null before the call, as required
+/// by the larod API.
+macro_rules! try_func {
+    ($func:path $(,)?) => {{
+        let mut error: *mut larod_sys::larodError = ::std::ptr::null_mut();
+        let result = $func(&mut error);
+        if error.is_null() {
+            (result, None)
+        } else {
+            // SAFETY: error is non-null and was allocated by the larod call.
+            let err = $crate::LarodError::from_raw(error);
+            (result, Some($crate::Error::Larod(err)))
+        }
+    }};
+    ($func:path, $($arg:expr),+ $(,)?) => {{
+        let mut error: *mut larod_sys::larodError = ::std::ptr::null_mut();
+        let result = $func($( $arg ),+, &mut error);
+        if error.is_null() {
+            (result, None)
+        } else {
+            // SAFETY: error is non-null and was allocated by the larod call.
+            let err = $crate::LarodError::from_raw(error);
+            (result, Some($crate::Error::Larod(err)))
+        }
+    }};
+}
+
+/// Error type for larod operations.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Larod(#[from] LarodError),
+    #[error("larod returned an unexpected null pointer")]
+    NullPointer,
+    #[error("missing error data from larod library")]
+    MissingError,
+    #[error("invalid file descriptor returned by larod: {0}")]
+    InvalidFd(i32),
+}
+
+/// Error from the larod library.
+///
+/// Contains a copy of the error code and message. The original `larodError`
+/// is freed immediately after copying via `larodClearError`.
+pub struct LarodError {
+    code: larodErrorCode,
+    message: String,
+}
+
+impl LarodError {
+    /// Copies data from a raw `larodError` pointer and frees it.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be a valid, non-null `larodError` pointer allocated by the larod library.
+    pub(crate) unsafe fn from_raw(raw: *mut larod_sys::larodError) -> Self {
+        assert!(!raw.is_null());
+
+        // SAFETY: raw is non-null. We copy all fields before larodClearError
+        // frees the struct and its contents (including the msg string).
+        let larod_err = unsafe { *raw };
+        let message = if larod_err.msg.is_null() {
+            String::from("(no message from library)")
+        } else {
+            let cstr = unsafe { CStr::from_ptr(larod_err.msg) };
+            String::from_utf8_lossy(cstr.to_bytes()).into_owned()
+        };
+        let code = larod_err.code;
+
+        let mut raw = raw;
+        // SAFETY: raw is a valid larodError pointer and larodClearError accepts
+        // a pointer to it, then nulls it after freeing.
+        unsafe { larod_sys::larodClearError(&mut raw) };
+
+        LarodError { code, message }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test(code: larodErrorCode, message: String) -> Self {
+        Self { code, message }
+    }
+
+    pub fn code_name(&self) -> &'static str {
+        match self.code {
+            larodErrorCode::LAROD_ERROR_NONE => "LAROD_ERROR_NONE",
+            larodErrorCode::LAROD_ERROR_JOB => "LAROD_ERROR_JOB",
+            larodErrorCode::LAROD_ERROR_LOAD_MODEL => "LAROD_ERROR_LOAD_MODEL",
+            larodErrorCode::LAROD_ERROR_FD => "LAROD_ERROR_FD",
+            larodErrorCode::LAROD_ERROR_MODEL_NOT_FOUND => "LAROD_ERROR_MODEL_NOT_FOUND",
+            larodErrorCode::LAROD_ERROR_PERMISSION => "LAROD_ERROR_PERMISSION",
+            larodErrorCode::LAROD_ERROR_CONNECTION => "LAROD_ERROR_CONNECTION",
+            larodErrorCode::LAROD_ERROR_CREATE_SESSION => "LAROD_ERROR_CREATE_SESSION",
+            larodErrorCode::LAROD_ERROR_KILL_SESSION => "LAROD_ERROR_KILL_SESSION",
+            larodErrorCode::LAROD_ERROR_INVALID_CHIP_ID => "LAROD_ERROR_INVALID_CHIP_ID",
+            larodErrorCode::LAROD_ERROR_INVALID_ACCESS => "LAROD_ERROR_INVALID_ACCESS",
+            larodErrorCode::LAROD_ERROR_DELETE_MODEL => "LAROD_ERROR_DELETE_MODEL",
+            larodErrorCode::LAROD_ERROR_TENSOR_MISMATCH => "LAROD_ERROR_TENSOR_MISMATCH",
+            larodErrorCode::LAROD_ERROR_VERSION_MISMATCH => "LAROD_ERROR_VERSION_MISMATCH",
+            larodErrorCode::LAROD_ERROR_ALLOC => "LAROD_ERROR_ALLOC",
+            larodErrorCode::LAROD_ERROR_POWER_NOT_AVAILABLE => "LAROD_ERROR_POWER_NOT_AVAILABLE",
+            _ => "LAROD_ERROR_UNKNOWN",
+        }
+    }
+
+    pub fn code(&self) -> larodErrorCode {
+        self.code
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Display for LarodError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} ({}): {}",
+            self.code_name(),
+            self.code.0,
+            self.message
+        )
+    }
+}
+
+impl Debug for LarodError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LarodError")
+            .field("code", &self.code)
+            .field("code_name", &self.code_name())
+            .field("message", &self.message)
+            .finish()
+    }
+}
+
+// Required: thiserror's #[from] on Error::Larod needs LarodError: std::error::Error.
+impl std::error::Error for LarodError {}

--- a/crates/larod/src/job.rs
+++ b/crates/larod/src/job.rs
@@ -1,0 +1,130 @@
+use std::marker::PhantomData;
+
+use crate::connection::Connection;
+use crate::model::Model;
+use crate::tensor::Tensors;
+use crate::{Error, Map};
+
+/// A job request that binds a model to input/output tensors for inference.
+///
+/// The job request holds references to the connection, model, and tensor arrays.
+/// All referenced objects must outlive the job request.
+pub struct JobRequest<'a> {
+    raw: *mut larod_sys::larodJobRequest,
+    conn_raw: *mut larod_sys::larodConnection,
+    // 'a is constrained by the constructor to the shortest of conn, model,
+    // inputs, outputs. conn_raw is stored as a raw pointer (not &Connection)
+    // so that Send does not require Connection: Sync.
+    _conn: PhantomData<&'a Connection>,
+    _model: PhantomData<&'a Model>,
+    _tensors: PhantomData<&'a ()>,
+    _params: PhantomData<&'a Map>,
+}
+
+impl<'a> JobRequest<'a> {
+    /// Create a new job request.
+    ///
+    /// # Arguments
+    ///
+    /// * `conn` - Connection for running the job
+    /// * `model` - The model to run inference with
+    /// * `inputs` - Input tensor array
+    /// * `outputs` - Output tensor array
+    /// * `params` - Optional parameters map
+    pub fn try_new(
+        conn: &'a Connection,
+        model: &'a Model,
+        inputs: &'a Tensors<'_>,
+        outputs: &'a Tensors<'_>,
+        params: Option<&'a Map>,
+    ) -> Result<Self, Error> {
+        let params_ptr = params.map_or(std::ptr::null_mut(), |p| p.as_ptr());
+        // SAFETY: model, inputs, outputs are valid larod objects. The lifetime 'a
+        // ensures they all outlive this JobRequest. params_ptr is null or valid.
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodCreateJobRequest,
+                model.as_ptr(),
+                inputs.as_ptr(),
+                inputs.len(),
+                outputs.as_ptr(),
+                outputs.len(),
+                params_ptr,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Ok(Self {
+            raw: ptr,
+            conn_raw: conn.raw,
+            _conn: PhantomData,
+            _model: PhantomData,
+            _tensors: PhantomData,
+            _params: PhantomData,
+        })
+    }
+
+    /// Run inference synchronously.
+    ///
+    /// After completion, the output tensors' backing memory contains the
+    /// inference results.
+    pub fn run(&self) -> Result<(), Error> {
+        // SAFETY: conn_raw and self.raw are valid pointers. The lifetime 'a
+        // ensures the connection and job request are both still alive.
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodRunJob, self.conn_raw, self.raw as *const _,) };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    /// Set the job priority (0 = lowest, 255 = highest).
+    pub fn set_priority(&mut self, priority: u8) -> Result<(), Error> {
+        // SAFETY: self.raw is a valid job request pointer.
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetJobRequestPriority, self.raw, priority,) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    /// Set optional parameters for this job request.
+    pub fn set_params(&mut self, params: &'a Map) -> Result<(), Error> {
+        // SAFETY: self.raw and params pointer are valid.
+        // Cast to *const because larodSetJobRequestParams takes *const larodMap.
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodSetJobRequestParams,
+                self.raw,
+                params.as_ptr() as *const _,
+            )
+        };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+}
+
+impl std::fmt::Debug for JobRequest<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobRequest")
+            .field("raw", &self.raw)
+            .finish()
+    }
+}
+
+impl Drop for JobRequest<'_> {
+    fn drop(&mut self) {
+        // larodDestroyJobRequest takes *mut *mut and nulls the pointer.
+        unsafe { larod_sys::larodDestroyJobRequest(&mut self.raw) }
+    }
+}

--- a/crates/larod/src/lib.rs
+++ b/crates/larod/src/lib.rs
@@ -1,0 +1,266 @@
+//! Safe Rust bindings for the [Larod (ML Inference) API](https://axiscommunications.github.io/acap-documentation/docs/api/src/api/larod/html/index.html).
+//!
+//! Larod provides access to hardware-accelerated ML inference on Axis cameras,
+//! supporting various backends (CPU, GPU, DLPU/NPU) and model formats (TFLite,
+//! ONNX, etc.).
+//!
+//! # Example
+//!
+//! ```no_run
+//! use larod::Connection;
+//!
+//! let conn = Connection::try_new().expect("Failed to connect to larod");
+//! let devices = conn.devices().expect("Failed to list devices");
+//! for dev in &devices {
+//!     println!("Device: {:?}", dev.name().unwrap());
+//! }
+//! ```
+//!
+//! # Typical workflow
+//!
+//! 1. Create a [`Connection`]
+//! 2. Get a [`Device`] (e.g. `conn.device(c"cpu-tflite", 0)`)
+//! 3. Load a [`Model`] from a file descriptor
+//! 4. Allocate input/output [`Tensors`] via the connection
+//! 5. Write input data to the input tensors' file descriptors
+//! 6. Create a [`JobRequest`] and call [`JobRequest::run()`]
+//! 7. Read results from the output tensors' file descriptors
+//!
+//! # Compile-time safety checks
+//!
+//! Connection-bound tensor arrays must not be sent to another thread while the
+//! original connection can still be used.
+//!
+//! ```compile_fail
+//! fn tensors_are_not_send(tensors: larod::Tensors<'_>) {
+//!     std::thread::scope(|scope| {
+//!         scope.spawn(move || drop(tensors));
+//!     });
+//! }
+//! ```
+//!
+//! Connection-bound job requests must not be sent to another thread while the
+//! original connection can still be used.
+//!
+//! ```compile_fail
+//! fn job_requests_are_not_send(job: larod::JobRequest<'_>) {
+//!     std::thread::scope(|scope| {
+//!         scope.spawn(move || drop(job));
+//!     });
+//! }
+//! ```
+//!
+//! Raw tensor file descriptor access requires an explicit unsafe block because
+//! callers must uphold the fd lifetime and ownership contract.
+//!
+//! ```compile_fail
+//! fn tensor_fd_getter_requires_unsafe(tensor: &larod::TensorRef<'_>) {
+//!     let _ = tensor.fd();
+//! }
+//! ```
+//!
+//! ```compile_fail
+//! fn tensor_fd_setter_requires_unsafe(tensor: &mut larod::TensorMut<'_>) {
+//!     let _ = tensor.set_fd(0);
+//! }
+//! ```
+//!
+//! Job request parameters must outlive the job request if they are set after
+//! construction.
+//!
+//! ```compile_fail
+//! fn job_params_must_outlive_request<'a>(mut job: larod::JobRequest<'a>) {
+//!     let map = larod::Map::try_new().unwrap();
+//!     job.set_params(&map).unwrap();
+//! }
+//! ```
+
+#[macro_use]
+mod error;
+mod connection;
+mod device;
+mod job;
+mod map;
+mod model;
+mod tensor;
+
+pub use connection::Connection;
+pub use device::Device;
+pub use error::{Error, LarodError};
+pub use job::JobRequest;
+pub use map::Map;
+pub use model::Model;
+pub use tensor::{TensorMut, TensorRef, Tensors, TensorsIter, TensorsIterMut};
+
+// Re-export commonly used larod-sys types.
+pub use larod_sys::{
+    larodAccess, larodErrorCode, larodTensorDataType, larodTensorDims, larodTensorLayout,
+    larodTensorPitches,
+};
+
+/// The tensor file descriptor can be read from and written to.
+pub const FD_PROP_READWRITE: u32 = 1 << 0;
+/// The tensor file descriptor can be memory-mapped.
+pub const FD_PROP_MAP: u32 = 1 << 1;
+/// The tensor file descriptor is a DMA buffer.
+pub const FD_PROP_DMABUF: u32 = 1 << 2;
+/// File descriptor properties for a DMA tensor buffer.
+pub const FD_TYPE_DMA: u32 = FD_PROP_DMABUF | FD_PROP_MAP;
+/// File descriptor properties for a disk-backed tensor buffer.
+pub const FD_TYPE_DISK: u32 = FD_PROP_READWRITE | FD_PROP_MAP;
+
+#[cfg(test)]
+mod tests {
+    use crate::LarodError;
+    use expect_test::expect;
+    use larod_sys::larodErrorCode;
+
+    #[test]
+    fn error_display() {
+        let err = LarodError::new_for_test(
+            larodErrorCode::LAROD_ERROR_CONNECTION,
+            "test error".to_string(),
+        );
+        expect![[r#"LAROD_ERROR_CONNECTION (-6): test error"#]].assert_eq(&err.to_string());
+    }
+
+    #[test]
+    fn error_code_names() {
+        let cases = [
+            (larodErrorCode::LAROD_ERROR_NONE, "LAROD_ERROR_NONE"),
+            (larodErrorCode::LAROD_ERROR_JOB, "LAROD_ERROR_JOB"),
+            (
+                larodErrorCode::LAROD_ERROR_LOAD_MODEL,
+                "LAROD_ERROR_LOAD_MODEL",
+            ),
+            (larodErrorCode::LAROD_ERROR_FD, "LAROD_ERROR_FD"),
+            (
+                larodErrorCode::LAROD_ERROR_MODEL_NOT_FOUND,
+                "LAROD_ERROR_MODEL_NOT_FOUND",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_PERMISSION,
+                "LAROD_ERROR_PERMISSION",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_CONNECTION,
+                "LAROD_ERROR_CONNECTION",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_CREATE_SESSION,
+                "LAROD_ERROR_CREATE_SESSION",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_KILL_SESSION,
+                "LAROD_ERROR_KILL_SESSION",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_INVALID_CHIP_ID,
+                "LAROD_ERROR_INVALID_CHIP_ID",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_INVALID_ACCESS,
+                "LAROD_ERROR_INVALID_ACCESS",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_DELETE_MODEL,
+                "LAROD_ERROR_DELETE_MODEL",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_TENSOR_MISMATCH,
+                "LAROD_ERROR_TENSOR_MISMATCH",
+            ),
+            (
+                larodErrorCode::LAROD_ERROR_VERSION_MISMATCH,
+                "LAROD_ERROR_VERSION_MISMATCH",
+            ),
+            (larodErrorCode::LAROD_ERROR_ALLOC, "LAROD_ERROR_ALLOC"),
+            (
+                larodErrorCode::LAROD_ERROR_POWER_NOT_AVAILABLE,
+                "LAROD_ERROR_POWER_NOT_AVAILABLE",
+            ),
+            (larodErrorCode(999), "LAROD_ERROR_UNKNOWN"),
+        ];
+        for (code, expected_name) in cases {
+            let err = LarodError::new_for_test(code, String::new());
+            assert_eq!(err.code_name(), expected_name, "for code {:?}", code);
+        }
+    }
+
+    #[test]
+    fn fd_flag_constants_match_larod_docs() {
+        assert_eq!(crate::FD_PROP_READWRITE, 1);
+        assert_eq!(crate::FD_PROP_MAP, 2);
+        assert_eq!(crate::FD_PROP_DMABUF, 4);
+        assert_eq!(crate::FD_TYPE_DMA, 6);
+        assert_eq!(crate::FD_TYPE_DISK, 3);
+    }
+}
+
+/// Tests that require the larod daemon and at least one inference device.
+/// Run with: `cargo test --features device-tests` on Axis camera hardware.
+#[cfg(feature = "device-tests")]
+#[cfg(test)]
+mod device_tests {
+    use crate::{Connection, Map};
+
+    #[test]
+    fn connect_and_list_sessions() {
+        let conn = Connection::try_new().expect("connect");
+        let sessions = conn.num_sessions().expect("num_sessions");
+        assert!(sessions >= 1, "at least our own session should be counted");
+    }
+
+    #[test]
+    fn list_devices() {
+        let conn = Connection::try_new().expect("connect");
+        let devices = conn.devices().expect("devices");
+        assert!(!devices.is_empty(), "should have at least one device");
+
+        for dev in &devices {
+            let name = dev.name().expect("device name");
+            assert!(!name.is_empty(), "device name should not be empty");
+            let _instance = dev.instance().expect("device instance");
+        }
+    }
+
+    #[test]
+    fn get_device_by_name() {
+        let conn = Connection::try_new().expect("connect");
+        let devices = conn.devices().expect("devices");
+        assert!(!devices.is_empty());
+
+        // Look up the first device by its name and instance.
+        let first = &devices[0];
+        let name = first.name().expect("name");
+        let instance = first.instance().expect("instance");
+
+        let looked_up = conn.device(name, instance).expect("get device");
+        assert_eq!(
+            looked_up.name().expect("name"),
+            name,
+            "looked-up device name should match"
+        );
+    }
+
+    #[test]
+    fn map_round_trip() {
+        let mut map = Map::try_new().expect("create map");
+
+        map.set_str(c"key1", c"value1").expect("set_str");
+        let v = map.get_str(c"key1").expect("get_str");
+        assert_eq!(v.unwrap(), c"value1");
+
+        map.set_int(c"num", 42).expect("set_int");
+        assert_eq!(map.get_int(c"num").expect("get_int"), 42);
+
+        map.set_int_arr2(c"pair", 10, 20).expect("set_int_arr2");
+        assert_eq!(map.get_int_arr2(c"pair").expect("get_int_arr2"), [10, 20]);
+
+        map.set_int_arr4(c"quad", 1, 2, 3, 4).expect("set_int_arr4");
+        assert_eq!(
+            map.get_int_arr4(c"quad").expect("get_int_arr4"),
+            [1, 2, 3, 4]
+        );
+    }
+}

--- a/crates/larod/src/map.rs
+++ b/crates/larod/src/map.rs
@@ -1,0 +1,184 @@
+use std::ffi::{c_char, CStr};
+
+use crate::Error;
+
+/// A key-value parameter map for larod operations.
+///
+/// Used to pass optional parameters to model loading and tensor allocation.
+/// Supports string, integer, and integer array values.
+pub struct Map {
+    raw: *mut larod_sys::larodMap,
+}
+
+impl Map {
+    pub fn try_new() -> Result<Self, Error> {
+        let (map, maybe_error) = unsafe { try_func!(larod_sys::larodCreateMap) };
+        if map.is_null() {
+            Err(maybe_error.unwrap_or(Error::NullPointer))
+        } else {
+            debug_assert!(maybe_error.is_none());
+            Ok(Self { raw: map })
+        }
+    }
+
+    pub fn set_str(&mut self, key: &CStr, value: &CStr) -> Result<(), Error> {
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodMapSetStr,
+                self.raw,
+                key.as_ptr(),
+                value.as_ptr(),
+            )
+        };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    /// Returns the string value for `key`, or `None` if the key doesn't exist.
+    ///
+    /// The returned reference borrows from the map's internal storage.
+    pub fn get_str(&self, key: &CStr) -> Result<Option<&CStr>, Error> {
+        // larodMapGetStr takes *mut larodMap (not *const) per the C API.
+        let (ptr, maybe_error): (*const c_char, _) =
+            unsafe { try_func!(larod_sys::larodMapGetStr, self.raw, key.as_ptr()) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        if ptr.is_null() {
+            Ok(None)
+        } else {
+            // SAFETY: ptr is non-null and points into the map's internal storage.
+            // The borrow from &self ensures the map (and thus the string) outlives
+            // the returned reference.
+            Ok(Some(unsafe { CStr::from_ptr(ptr) }))
+        }
+    }
+
+    pub fn set_int(&mut self, key: &CStr, value: i64) -> Result<(), Error> {
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodMapSetInt, self.raw, key.as_ptr(), value) };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn get_int(&self, key: &CStr) -> Result<i64, Error> {
+        let mut value: i64 = 0;
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodMapGetInt,
+                self.raw,
+                key.as_ptr(),
+                &mut value,
+            )
+        };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(value)
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn set_int_arr2(&mut self, key: &CStr, v0: i64, v1: i64) -> Result<(), Error> {
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodMapSetIntArr2,
+                self.raw,
+                key.as_ptr(),
+                v0,
+                v1,
+            )
+        };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    /// Returns a 2-element array, or an error if the key doesn't exist.
+    pub fn get_int_arr2(&self, key: &CStr) -> Result<[i64; 2], Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodMapGetIntArr2, self.raw, key.as_ptr()) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        if ptr.is_null() {
+            return Err(Error::NullPointer);
+        }
+        // SAFETY: ptr points to at least 2 i64 values in the map's internal storage.
+        Ok(unsafe { [*ptr, *ptr.add(1)] })
+    }
+
+    pub fn set_int_arr4(
+        &mut self,
+        key: &CStr,
+        v0: i64,
+        v1: i64,
+        v2: i64,
+        v3: i64,
+    ) -> Result<(), Error> {
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodMapSetIntArr4,
+                self.raw,
+                key.as_ptr(),
+                v0,
+                v1,
+                v2,
+                v3,
+            )
+        };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    /// Returns a 4-element array, or an error if the key doesn't exist.
+    pub fn get_int_arr4(&self, key: &CStr) -> Result<[i64; 4], Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodMapGetIntArr4, self.raw, key.as_ptr()) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        if ptr.is_null() {
+            return Err(Error::NullPointer);
+        }
+        // SAFETY: ptr points to at least 4 i64 values in the map's internal storage.
+        Ok(unsafe { [*ptr, *ptr.add(1), *ptr.add(2), *ptr.add(3)] })
+    }
+
+    // *mut because the C API takes *mut even for read-only operations.
+    pub(crate) fn as_ptr(&self) -> *mut larod_sys::larodMap {
+        self.raw
+    }
+}
+
+impl std::fmt::Debug for Map {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Map").field("raw", &self.raw).finish()
+    }
+}
+
+// SAFETY: We hold exclusive ownership of the raw pointer and larodMap
+// does not require access from a specific thread.
+unsafe impl Send for Map {}
+
+impl Drop for Map {
+    fn drop(&mut self) {
+        // larodDestroyMap takes *mut *mut larodMap and nulls the pointer.
+        unsafe { larod_sys::larodDestroyMap(&mut self.raw) }
+    }
+}

--- a/crates/larod/src/model.rs
+++ b/crates/larod/src/model.rs
@@ -1,0 +1,223 @@
+use std::ffi::CStr;
+
+use crate::connection::Connection;
+use crate::tensor::Tensors;
+use crate::Error;
+
+pub use larod_sys::larodAccess;
+
+/// A loaded ML model.
+///
+/// Models are loaded via [`Connection::load_model`] and destroyed when dropped.
+/// The model handle is local to this process - dropping it does not remove the
+/// model from the larod daemon (use [`Model::delete`] for that).
+pub struct Model {
+    pub(crate) raw: *mut larod_sys::larodModel,
+}
+
+impl Model {
+    pub(crate) fn from_raw(raw: *mut larod_sys::larodModel) -> Result<Self, Error> {
+        if raw.is_null() {
+            return Err(Error::NullPointer);
+        }
+        Ok(Self { raw })
+    }
+
+    /// Returns the server-assigned model ID.
+    pub fn id(&self) -> Result<u64, Error> {
+        let (id, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetModelId, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(id)
+    }
+
+    /// Returns the model name, or `None` if no name was set.
+    pub fn name(&self) -> Result<Option<&CStr>, Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetModelName, self.raw as *const _) };
+        if ptr.is_null() {
+            if let Some(err) = maybe_error {
+                return Err(err);
+            }
+            return Ok(None);
+        }
+        debug_assert!(maybe_error.is_none());
+        // SAFETY: ptr is non-null, points into model's internal storage.
+        Ok(Some(unsafe { CStr::from_ptr(ptr) }))
+    }
+
+    pub fn access(&self) -> Result<larodAccess, Error> {
+        let (access, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetModelAccess, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(access)
+    }
+
+    /// Returns the model size in bytes.
+    pub fn size(&self) -> Result<usize, Error> {
+        let (size, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetModelSize, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(size)
+    }
+
+    pub fn num_inputs(&self) -> Result<usize, Error> {
+        let (n, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetModelNumInputs, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(n)
+    }
+
+    pub fn num_outputs(&self) -> Result<usize, Error> {
+        let (n, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetModelNumOutputs, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(n)
+    }
+
+    /// Returns the byte sizes of all input tensors.
+    ///
+    /// The returned Vec is copied from a C-heap-allocated array which is freed
+    /// after copying.
+    pub fn input_byte_sizes(&self) -> Result<Vec<usize>, Error> {
+        let mut num: usize = 0;
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodGetModelInputByteSizes,
+                self.raw as *const _,
+                &mut num,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        let guard = CArrayGuard { raw: ptr };
+        // SAFETY: ptr points to num usize values allocated by larod (C heap).
+        let sizes = unsafe { std::slice::from_raw_parts(guard.raw, num) }.to_vec();
+        Ok(sizes)
+    }
+
+    /// Returns the byte sizes of all output tensors.
+    pub fn output_byte_sizes(&self) -> Result<Vec<usize>, Error> {
+        let mut num: usize = 0;
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodGetModelOutputByteSizes,
+                self.raw as *const _,
+                &mut num,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        let guard = CArrayGuard { raw: ptr };
+        // SAFETY: ptr points to num usize values allocated by larod (C heap).
+        let sizes = unsafe { std::slice::from_raw_parts(guard.raw, num) }.to_vec();
+        Ok(sizes)
+    }
+
+    /// Create tensor descriptors pre-configured with the model's input metadata.
+    /// No backing memory is allocated - use `Connection::alloc_model_inputs` for that.
+    pub fn create_inputs<'conn>(&self, conn: &'conn Connection) -> Result<Tensors<'conn>, Error> {
+        let mut num: usize = 0;
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodCreateModelInputs,
+                self.raw as *const _,
+                &mut num,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Tensors::from_raw(ptr, num, conn)
+    }
+
+    /// Create tensor descriptors pre-configured with the model's output metadata.
+    pub fn create_outputs<'conn>(&self, conn: &'conn Connection) -> Result<Tensors<'conn>, Error> {
+        let mut num: usize = 0;
+        let (ptr, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodCreateModelOutputs,
+                self.raw as *const _,
+                &mut num,
+            )
+        };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        debug_assert!(maybe_error.is_none());
+        Tensors::from_raw(ptr, num, conn)
+    }
+
+    /// Delete this model from the larod daemon.
+    ///
+    /// This removes the model from the server. For private models, only the
+    /// loading session can delete. For public models, any session can delete.
+    pub fn delete(self, conn: &Connection) -> Result<(), Error> {
+        let raw = self.raw;
+        // Prevent Drop from calling larodDestroyModel - we handle cleanup here.
+        // On success, larodDeleteModel already removes the model.
+        // On failure, we still need to destroy the local handle.
+        std::mem::forget(self);
+
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodDeleteModel, conn.raw, raw) };
+        if success {
+            debug_assert!(maybe_error.is_none());
+            // Model deleted server-side. Destroy the local handle.
+            let mut raw = raw;
+            unsafe { larod_sys::larodDestroyModel(&mut raw) };
+            Ok(())
+        } else {
+            // Delete failed - still destroy the local handle to avoid leaking.
+            let mut raw = raw;
+            unsafe { larod_sys::larodDestroyModel(&mut raw) };
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *const larod_sys::larodModel {
+        self.raw as *const _
+    }
+}
+
+impl std::fmt::Debug for Model {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Model").field("raw", &self.raw).finish()
+    }
+}
+
+// SAFETY: We hold exclusive ownership of the raw pointer and the larod
+// model handle does not require access from a specific thread.
+unsafe impl Send for Model {}
+
+impl Drop for Model {
+    fn drop(&mut self) {
+        // larodDestroyModel takes *mut *mut larodModel and nulls the pointer.
+        unsafe { larod_sys::larodDestroyModel(&mut self.raw) }
+    }
+}
+
+struct CArrayGuard<T> {
+    raw: *mut T,
+}
+
+impl<T> Drop for CArrayGuard<T> {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.raw as *mut libc::c_void) }
+    }
+}

--- a/crates/larod/src/tensor.rs
+++ b/crates/larod/src/tensor.rs
@@ -1,0 +1,605 @@
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::os::raw::c_int;
+
+use crate::connection::Connection;
+use crate::Error;
+
+pub use larod_sys::{larodTensorDataType, larodTensorDims, larodTensorLayout, larodTensorPitches};
+
+/// An owned array of tensor descriptors.
+///
+/// Tensors in larod are always created and destroyed as arrays. This wrapper
+/// owns the entire C-allocated array and provides indexed access to individual
+/// tensors.
+///
+/// Requires a connection because `larodDestroyTensors` needs it to release
+/// any server-tracked file descriptors.
+pub struct Tensors<'conn> {
+    raw: *mut *mut larod_sys::larodTensor,
+    len: usize,
+    // Raw pointer (not &Connection) so Send doesn't require Connection: Sync.
+    conn_raw: *mut larod_sys::larodConnection,
+    _conn: PhantomData<&'conn Connection>,
+}
+
+impl<'conn> Tensors<'conn> {
+    pub(crate) fn from_raw(
+        raw: *mut *mut larod_sys::larodTensor,
+        len: usize,
+        conn: &'conn Connection,
+    ) -> Result<Self, Error> {
+        if raw.is_null() {
+            return Err(Error::NullPointer);
+        }
+
+        for i in 0..len {
+            let tensor = unsafe { *raw.add(i) };
+            if tensor.is_null() {
+                destroy_tensors(conn.raw, raw, len);
+                return Err(Error::NullPointer);
+            }
+            for j in 0..i {
+                let prior = unsafe { *raw.add(j) };
+                if prior == tensor {
+                    destroy_tensors(conn.raw, raw, len);
+                    return Err(Error::NullPointer);
+                }
+            }
+        }
+
+        Ok(Self {
+            raw,
+            len,
+            conn_raw: conn.raw,
+            _conn: PhantomData,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Access a single tensor by index.
+    pub fn get(&self, index: usize) -> Option<TensorRef<'_>> {
+        if index >= self.len {
+            return None;
+        }
+        // SAFETY: index is in bounds. The tensor pointer is valid for the
+        // lifetime of this Tensors array.
+        let ptr = unsafe { *self.raw.add(index) };
+        Some(TensorRef {
+            raw: ptr,
+            _tensors: PhantomData,
+        })
+    }
+
+    /// Access a single mutable tensor by index.
+    pub fn get_mut(&mut self, index: usize) -> Option<TensorMut<'_>> {
+        if index >= self.len {
+            return None;
+        }
+        // SAFETY: index is in bounds (checked above). The pointer is valid for
+        // the lifetime of this Tensors array. The &mut self borrow prevents
+        // concurrent access to any other tensor in the array.
+        let ptr = unsafe { *self.raw.add(index) };
+        Some(TensorMut {
+            raw: ptr,
+            _tensors: PhantomData,
+        })
+    }
+
+    /// Returns the raw pointer array for passing to C functions like
+    /// `larodCreateJobRequest`.
+    pub(crate) fn as_ptr(&self) -> *mut *mut larod_sys::larodTensor {
+        self.raw
+    }
+
+    /// Returns an iterator over immutable tensor references.
+    pub fn iter(&self) -> TensorsIter<'_> {
+        TensorsIter {
+            raw: self.raw,
+            len: self.len,
+            index: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns an iterator over mutable tensor references.
+    pub fn iter_mut(&mut self) -> TensorsIterMut<'_> {
+        TensorsIterMut {
+            raw: self.raw,
+            len: self.len,
+            index: 0,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, 'conn> IntoIterator for &'a Tensors<'conn> {
+    type Item = TensorRef<'a>;
+    type IntoIter = TensorsIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, 'conn> IntoIterator for &'a mut Tensors<'conn> {
+    type Item = TensorMut<'a>;
+    type IntoIter = TensorsIterMut<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+/// Iterator over immutable tensor references.
+pub struct TensorsIter<'a> {
+    raw: *mut *mut larod_sys::larodTensor,
+    len: usize,
+    index: usize,
+    _marker: PhantomData<&'a ()>,
+}
+
+impl<'a> Iterator for TensorsIter<'a> {
+    type Item = TensorRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        // SAFETY: index is in-bounds (checked above). The pointer is valid for
+        // the lifetime of this iterator which borrows from Tensors.
+        let ptr = unsafe { *self.raw.add(self.index) };
+        self.index += 1;
+        Some(TensorRef {
+            raw: ptr,
+            _tensors: PhantomData,
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for TensorsIter<'_> {}
+impl std::iter::FusedIterator for TensorsIter<'_> {}
+
+/// Iterator over mutable tensor references.
+pub struct TensorsIterMut<'a> {
+    raw: *mut *mut larod_sys::larodTensor,
+    len: usize,
+    index: usize,
+    _marker: PhantomData<&'a mut ()>,
+}
+
+impl<'a> Iterator for TensorsIterMut<'a> {
+    type Item = TensorMut<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        // SAFETY: Each index is yielded exactly once, so we don't create
+        // overlapping mutable references. The exclusive &mut Tensors borrow
+        // from iter_mut() prevents any concurrent access through the original.
+        let ptr = unsafe { *self.raw.add(self.index) };
+        self.index += 1;
+        Some(TensorMut {
+            raw: ptr,
+            _tensors: PhantomData,
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for TensorsIterMut<'_> {}
+impl std::iter::FusedIterator for TensorsIterMut<'_> {}
+
+impl std::fmt::Debug for Tensors<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Tensors")
+            .field("len", &self.len)
+            .field("raw", &self.raw)
+            .finish()
+    }
+}
+
+impl Drop for Tensors<'_> {
+    fn drop(&mut self) {
+        // larodDestroyTensors takes *mut *mut *mut larodTensor (triple pointer).
+        // We pass &mut self.raw which gives *mut (*mut *mut larodTensor).
+        let mut error: *mut larod_sys::larodError = std::ptr::null_mut();
+        let success = unsafe {
+            larod_sys::larodDestroyTensors(self.conn_raw, &mut self.raw, self.len, &mut error)
+        };
+        if !error.is_null() {
+            // SAFETY: error is non-null and allocated by larodDestroyTensors.
+            let err = unsafe { crate::LarodError::from_raw(error) };
+            if !success {
+                log::error!("Failed to destroy tensors: {err}");
+            }
+        } else if !success {
+            log::error!("Failed to destroy tensors (no error details)");
+        }
+    }
+}
+
+/// Immutable reference to a single tensor within a [`Tensors`] array.
+pub struct TensorRef<'a> {
+    raw: *mut larod_sys::larodTensor,
+    _tensors: PhantomData<&'a ()>,
+}
+
+impl<'a> TensorRef<'a> {
+    pub fn dims(&self) -> Result<&larodTensorDims, Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorDims, self.raw as *const _,) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        // SAFETY: ptr is non-null and points into the tensor's internal storage.
+        Ok(unsafe { &*ptr })
+    }
+
+    pub fn pitches(&self) -> Result<&larodTensorPitches, Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorPitches, self.raw as *const _,) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        Ok(unsafe { &*ptr })
+    }
+
+    pub fn data_type(&self) -> Result<larodTensorDataType, Error> {
+        let (dt, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorDataType, self.raw as *const _,) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(dt)
+    }
+
+    pub fn layout(&self) -> Result<larodTensorLayout, Error> {
+        let (layout, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorLayout, self.raw as *const _,) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(layout)
+    }
+
+    /// Returns the tensor's file descriptor, or `None` if no fd has been assigned.
+    ///
+    /// # Safety
+    ///
+    /// The returned raw fd is owned according to the larod tensor contract. The
+    /// caller must not close it or extend its use beyond the tensor/connection
+    /// lifetime unless the underlying larod API explicitly transfers ownership.
+    pub unsafe fn fd(&self) -> Result<Option<c_int>, Error> {
+        let (fd, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorFd, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        decode_fd(fd, maybe_error)
+    }
+
+    pub fn fd_size(&self) -> Result<usize, Error> {
+        let mut size: usize = 0;
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodGetTensorFdSize,
+                self.raw as *const _,
+                &mut size,
+            )
+        };
+        if success {
+            Ok(size)
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn fd_offset(&self) -> Result<i64, Error> {
+        let (offset, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorFdOffset, self.raw as *const _,) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(offset)
+    }
+
+    pub fn name(&self) -> Result<&CStr, Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorName, self.raw as *const _,) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        // SAFETY: ptr is non-null and points into the tensor's internal storage.
+        // Lifetime is tied to 'a via the PhantomData borrow from the Tensors array.
+        Ok(unsafe { CStr::from_ptr(ptr) })
+    }
+
+    pub fn byte_size(&self) -> Result<usize, Error> {
+        let mut size: usize = 0;
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodGetTensorByteSize,
+                self.raw as *const _,
+                &mut size,
+            )
+        };
+        if success {
+            Ok(size)
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+}
+
+/// Mutable reference to a single tensor within a [`Tensors`] array.
+// Invariant: raw pointer is from a valid Tensors element, Tensors outlives
+// this via 'a, and no aliasing TensorMut exists (enforced by &mut self on
+// get_mut and exclusive iteration).
+pub struct TensorMut<'a> {
+    raw: *mut larod_sys::larodTensor,
+    _tensors: PhantomData<&'a mut ()>,
+}
+
+impl<'a> TensorMut<'a> {
+    pub fn set_dims(&mut self, dims: &larodTensorDims) -> Result<(), Error> {
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetTensorDims, self.raw, dims) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn set_pitches(&mut self, pitches: &larodTensorPitches) -> Result<(), Error> {
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetTensorPitches, self.raw, pitches) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn set_data_type(&mut self, data_type: larodTensorDataType) -> Result<(), Error> {
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetTensorDataType, self.raw, data_type) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn set_layout(&mut self, layout: larodTensorLayout) -> Result<(), Error> {
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetTensorLayout, self.raw, layout) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    /// Set the tensor's file descriptor.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the fd remains valid for as long as larod may use
+    /// this tensor, and that ownership/closing rules match the larod API.
+    pub unsafe fn set_fd(&mut self, fd: c_int) -> Result<(), Error> {
+        if fd < 0 {
+            return Err(Error::InvalidFd(fd));
+        }
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetTensorFd, self.raw, fd) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn set_fd_size(&mut self, size: usize) -> Result<(), Error> {
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetTensorFdSize, self.raw, size) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn set_fd_offset(&mut self, offset: i64) -> Result<(), Error> {
+        let (success, maybe_error) =
+            unsafe { try_func!(larod_sys::larodSetTensorFdOffset, self.raw, offset) };
+        if success {
+            Ok(())
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    // Read-only accessors (delegate to the same C functions as TensorRef).
+    pub fn dims(&self) -> Result<&larodTensorDims, Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorDims, self.raw as *const _) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        Ok(unsafe { &*ptr })
+    }
+
+    pub fn pitches(&self) -> Result<&larodTensorPitches, Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorPitches, self.raw as *const _) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        Ok(unsafe { &*ptr })
+    }
+
+    pub fn data_type(&self) -> Result<larodTensorDataType, Error> {
+        let (dt, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorDataType, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(dt)
+    }
+
+    pub fn layout(&self) -> Result<larodTensorLayout, Error> {
+        let (layout, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorLayout, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(layout)
+    }
+
+    /// Returns the tensor's file descriptor, or `None` if no fd has been assigned.
+    ///
+    /// # Safety
+    ///
+    /// The returned raw fd is owned according to the larod tensor contract. The
+    /// caller must not close it or extend its use beyond the tensor/connection
+    /// lifetime unless the underlying larod API explicitly transfers ownership.
+    pub unsafe fn fd(&self) -> Result<Option<c_int>, Error> {
+        let (fd, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorFd, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        decode_fd(fd, maybe_error)
+    }
+
+    pub fn fd_size(&self) -> Result<usize, Error> {
+        let mut size: usize = 0;
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodGetTensorFdSize,
+                self.raw as *const _,
+                &mut size,
+            )
+        };
+        if success {
+            Ok(size)
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn fd_offset(&self) -> Result<i64, Error> {
+        let (offset, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorFdOffset, self.raw as *const _) };
+        if let Some(err) = maybe_error {
+            return Err(err);
+        }
+        Ok(offset)
+    }
+
+    pub fn byte_size(&self) -> Result<usize, Error> {
+        let mut size: usize = 0;
+        let (success, maybe_error) = unsafe {
+            try_func!(
+                larod_sys::larodGetTensorByteSize,
+                self.raw as *const _,
+                &mut size,
+            )
+        };
+        if success {
+            Ok(size)
+        } else {
+            Err(maybe_error.unwrap_or(Error::MissingError))
+        }
+    }
+
+    pub fn name(&self) -> Result<&CStr, Error> {
+        let (ptr, maybe_error) =
+            unsafe { try_func!(larod_sys::larodGetTensorName, self.raw as *const _) };
+        if ptr.is_null() {
+            return Err(maybe_error.unwrap_or(Error::NullPointer));
+        }
+        // SAFETY: ptr is non-null and points into the tensor's internal storage.
+        // Lifetime is tied to 'a via the PhantomData borrow from the Tensors array.
+        Ok(unsafe { CStr::from_ptr(ptr) })
+    }
+}
+
+fn destroy_tensors(
+    conn_raw: *mut larod_sys::larodConnection,
+    raw: *mut *mut larod_sys::larodTensor,
+    len: usize,
+) {
+    let mut raw = raw;
+    let mut error: *mut larod_sys::larodError = std::ptr::null_mut();
+    let success = unsafe { larod_sys::larodDestroyTensors(conn_raw, &mut raw, len, &mut error) };
+    if !error.is_null() {
+        // SAFETY: error is non-null and allocated by larodDestroyTensors.
+        let err = unsafe { crate::LarodError::from_raw(error) };
+        if !success {
+            log::error!("Failed to destroy invalid tensor array: {err}");
+        }
+    } else if !success {
+        log::error!("Failed to destroy invalid tensor array (no error details)");
+    }
+}
+
+fn decode_fd(fd: c_int, maybe_error: Option<Error>) -> Result<Option<c_int>, Error> {
+    if let Some(err) = maybe_error {
+        return Err(err);
+    }
+    if fd == c_int::MIN {
+        Err(Error::MissingError)
+    } else if fd < 0 {
+        Err(Error::InvalidFd(fd))
+    } else {
+        Ok(Some(fd))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::raw::c_int;
+
+    use crate::Error;
+
+    #[test]
+    fn invalid_fd_sentinel_without_error_is_missing_error() {
+        assert!(matches!(
+            super::decode_fd(c_int::MIN, None),
+            Err(Error::MissingError)
+        ));
+    }
+
+    #[test]
+    fn other_negative_fd_is_invalid_fd() {
+        assert!(matches!(
+            super::decode_fd(-2, None),
+            Err(Error::InvalidFd(-2))
+        ));
+    }
+
+    #[test]
+    fn non_negative_fd_is_valid() {
+        assert!(matches!(super::decode_fd(0, None), Ok(Some(0))));
+    }
+}


### PR DESCRIPTION
### Safe Rust wrapper for the larod C API

Adds a new `larod` crate with safe Rust bindings around the larod C API. The wrapper covers connection management, device enumeration, model loading/retrieval, tensor allocation, job requests, parameter maps, and error handling.

### Review focus

- FFI ownership and cleanup paths for larod-managed pointers.
- Safe API boundaries for tensors, jobs, maps, and file-descriptor access.
- Error handling for null pointers, larod error objects, and fd sentinel values.
- Consistency with lessons from PR #223: fallible constructors, explicit unsafe contracts, no safe fd lifetime overclaims, and focused tests/docs.

### Current status

- Rebased onto `main` after PR #223 merged.
- History cleaned to one feature commit plus any future normal follow-up commits.
- PR is ready for review.

### Local verification

- [x] `cargo fmt -p larod -- --check`
- [x] `git diff --check`
- [x] `cargo test -p larod`
- [x] `cargo clippy -p larod --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-Dwarnings" cargo doc -p larod --document-private-items --no-deps`

### Issue ticket number and link

- [ ] N/A

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation