### PR TITLE
feat(cargo-acap-*): Add `--manifest-path`

### DIFF
--- a/crates/cargo-acap-build/src/cargo.rs
+++ b/crates/cargo-acap-build/src/cargo.rs
@@ -1,4 +1,6 @@
 /// Wrapper around `cargo`.
+use std::path::Path;
+
 use metadata::CargoMetadata;
 
 use crate::command_utils::RunWith;
@@ -6,8 +8,17 @@ use crate::command_utils::RunWith;
 pub mod json_message;
 pub mod metadata;
 
-pub fn get_cargo_metadata() -> anyhow::Result<CargoMetadata> {
-    let mut cargo = std::process::Command::new("cargo");
+pub(crate) fn cargo_command(manifest_path: Option<&Path>) -> std::process::Command {
+    let mut cmd = std::process::Command::new("cargo");
+    if let Some(path) = manifest_path {
+        cmd.arg("--manifest-path");
+        cmd.arg(path);
+    }
+    cmd
+}
+
+pub fn get_cargo_metadata(manifest_path: Option<&Path>) -> anyhow::Result<CargoMetadata> {
+    let mut cargo = cargo_command(manifest_path);
     cargo.arg("metadata");
     cargo.args(["--format-version", "1"]);
     let metadata = cargo.run_with_captured_stdout()?;

--- a/crates/cargo-acap-build/src/cargo_acap.rs
+++ b/crates/cargo-acap-build/src/cargo_acap.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Context};
 use log::{debug, error, warn};
 
 use crate::{
-    cargo::{get_cargo_metadata, json_message::JsonMessage},
+    cargo::{cargo_command, get_cargo_metadata, json_message::JsonMessage},
     command_utils::RunWith,
     files::license,
     Architecture,
@@ -21,11 +21,15 @@ pub enum Artifact {
     Eap { path: PathBuf, name: String },
     Exe { path: PathBuf },
 }
-pub fn build_and_pack(arch: Architecture, args: &[&str]) -> anyhow::Result<Vec<Artifact>> {
+pub fn build_and_pack(
+    arch: Architecture,
+    args: &[&str],
+    manifest_path: Option<&Path>,
+) -> anyhow::Result<Vec<Artifact>> {
     // If user supplies a target we lose track of which target is currently being built
     assert!(!args.contains(&"--target"));
 
-    let mut cargo = std::process::Command::new("cargo");
+    let mut cargo = cargo_command(manifest_path);
     cargo.arg("build");
     cargo.args(["--target", arch.triple()]);
 
@@ -49,7 +53,7 @@ pub fn build_and_pack(arch: Architecture, args: &[&str]) -> anyhow::Result<Vec<A
         Ok(())
     })?;
 
-    let cargo_target_directory = get_cargo_metadata()?.target_directory;
+    let cargo_target_directory = get_cargo_metadata(manifest_path)?.target_directory;
     let mut out_dirs = HashMap::new();
     let mut artifacts = Vec::new();
     for m in messages {

--- a/crates/cargo-acap-build/src/lib.rs
+++ b/crates/cargo-acap-build/src/lib.rs
@@ -20,6 +20,7 @@ pub struct AppBuilder {
     targets: Vec<Architecture>,
     args: Vec<String>,
     artifact_dir: Option<PathBuf>,
+    manifest_path: Option<PathBuf>,
 }
 
 impl AppBuilder {
@@ -32,6 +33,7 @@ impl AppBuilder {
             targets: targets.into_iter().map(|t| t.into()).collect(),
             args: Vec::new(),
             artifact_dir: None,
+            manifest_path: None,
         }
     }
 
@@ -41,6 +43,7 @@ impl AppBuilder {
     ///
     /// This function will panic if it detects one of the disallowed options:
     /// - `--artifact-dir`
+    /// - `--manifest-path`
     /// - `--target`
     ///
     /// <div class="warning">
@@ -55,6 +58,7 @@ impl AppBuilder {
             let arg: String = arg.to_string();
             let name = arg.split('=').next().unwrap();
             assert_ne!(name, "--artifact-dir");
+            assert_ne!(name, "--manifest-path");
             assert_ne!(name, "--target");
             arg
         }));
@@ -74,11 +78,25 @@ impl AppBuilder {
         self
     }
 
+    /// Path to Cargo.toml.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the manifest path has already been set.
+    pub fn manifest_path<T>(&mut self, manifest_path: T) -> &mut Self
+    where
+        T: Into<PathBuf>,
+    {
+        assert!(mem::replace(&mut self.manifest_path, Some(manifest_path.into())).is_none());
+        self
+    }
+
     pub fn execute(&mut self) -> anyhow::Result<Vec<Artifact>> {
         let args: Vec<_> = self.args.iter().map(String::as_str).collect();
+        let manifest_path = self.manifest_path.as_deref();
         let mut artifacts = Vec::new();
         for target in &self.targets {
-            artifacts.extend(cargo_acap::build_and_pack(*target, &args)?);
+            artifacts.extend(cargo_acap::build_and_pack(*target, &args, manifest_path)?);
         }
         if let Some(artifact_dir) = self.artifact_dir.as_deref() {
             copy_final_artifacts(&artifacts, artifact_dir)?;

--- a/crates/cargo-acap-build/src/main.rs
+++ b/crates/cargo-acap-build/src/main.rs
@@ -67,7 +67,7 @@ fn build_and_copy(cli: Cli) -> anyhow::Result<()> {
 
     AppBuilder::from_targets(cli.targets())
         .args(args)
-        .artifact_dir(get_cargo_metadata()?.target_directory.join("acap"))
+        .artifact_dir(get_cargo_metadata(None)?.target_directory.join("acap"))
         .execute()?;
     Ok(())
 }

--- a/crates/cargo-acap-sdk/src/commands/build_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/build_command.rs
@@ -12,7 +12,12 @@ pub struct BuildCommand {
 impl BuildCommand {
     pub fn exec(self) -> anyhow::Result<()> {
         let Self {
-            build_options: ResolvedBuildOptions { target, mut args },
+            build_options:
+                ResolvedBuildOptions {
+                    target,
+                    manifest_path,
+                    mut args,
+                },
         } = self;
 
         if !args.iter().any(|arg| {
@@ -25,9 +30,17 @@ impl BuildCommand {
             args.push("--profile=release".to_string());
         }
 
-        AppBuilder::from_targets([Architecture::from(target)])
-            .args(args)
-            .artifact_dir(get_cargo_metadata()?.target_directory.join("acap"))
+        let mut builder = AppBuilder::from_targets([Architecture::from(target)]);
+        builder.args(args);
+        if let Some(ref path) = manifest_path {
+            builder.manifest_path(path);
+        }
+        builder
+            .artifact_dir(
+                get_cargo_metadata(manifest_path.as_deref())?
+                    .target_directory
+                    .join("acap"),
+            )
             .execute()?;
         Ok(())
     }

--- a/crates/cargo-acap-sdk/src/commands/control_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/control_command.rs
@@ -44,7 +44,7 @@ impl ControlCommand {
 /// not work from the workspace root if it is not also the root of the binary crate whereas this
 /// will.
 fn infer_name_from_metadata() -> anyhow::Result<String> {
-    let metadata = get_cargo_metadata()?;
+    let metadata = get_cargo_metadata(None)?;
 
     let find_binary_targets = |id: &String| {
         metadata

--- a/crates/cargo-acap-sdk/src/commands/install_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/install_command.rs
@@ -22,8 +22,11 @@ impl InstallCommand {
             deploy_options,
         } = self;
 
-        let ResolvedBuildOptions { target, mut args } =
-            build_options.resolve(&deploy_options).await?;
+        let ResolvedBuildOptions {
+            target,
+            manifest_path,
+            mut args,
+        } = build_options.resolve(&deploy_options).await?;
 
         if !args.iter().any(|arg| {
             arg.split('=')
@@ -35,9 +38,12 @@ impl InstallCommand {
             args.push("--profile=release".to_string());
         }
 
-        let artifacts = AppBuilder::from_targets([Architecture::from(target)])
-            .args(args)
-            .execute()?;
+        let mut builder = AppBuilder::from_targets([Architecture::from(target)]);
+        builder.args(args);
+        if let Some(ref path) = manifest_path {
+            builder.manifest_path(path);
+        }
+        let artifacts = builder.execute()?;
 
         // TODO: Handle the case where multiple artifacts of the same kind have the same name.
         for artifact in artifacts {

--- a/crates/cargo-acap-sdk/src/commands/run_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/run_command.rs
@@ -18,7 +18,11 @@ impl RunCommand {
             deploy_options,
         } = self;
 
-        let ResolvedBuildOptions { target, args } = build_options.resolve(&deploy_options).await?;
+        let ResolvedBuildOptions {
+            target,
+            manifest_path,
+            args,
+        } = build_options.resolve(&deploy_options).await?;
 
         let DeployOptions {
             host: address,
@@ -30,9 +34,12 @@ impl RunCommand {
             pass: password,
         } = deploy_options;
 
-        let artifacts = AppBuilder::from_targets([Architecture::from(target)])
-            .args(args)
-            .execute()?;
+        let mut builder = AppBuilder::from_targets([Architecture::from(target)]);
+        builder.args(args);
+        if let Some(ref path) = manifest_path {
+            builder.manifest_path(path);
+        }
+        let artifacts = builder.execute()?;
         for artifact in artifacts {
             let envs = vec![("RUST_LOG", "debug"), ("RUST_LOG_STYLE", "always")]
                 .into_iter()

--- a/crates/cargo-acap-sdk/src/commands/test_command.rs
+++ b/crates/cargo-acap-sdk/src/commands/test_command.rs
@@ -20,6 +20,7 @@ impl TestCommand {
 
         let ResolvedBuildOptions {
             target,
+            manifest_path,
             args: mut build_args,
         } = build_options.resolve(&deploy_options).await?;
 
@@ -35,9 +36,12 @@ impl TestCommand {
 
         build_args.push("--tests".to_string());
 
-        let artifacts = AppBuilder::from_targets([Architecture::from(target)])
-            .args(build_args)
-            .execute()?;
+        let mut builder = AppBuilder::from_targets([Architecture::from(target)]);
+        builder.args(build_args);
+        if let Some(ref path) = manifest_path {
+            builder.manifest_path(path);
+        }
+        let artifacts = builder.execute()?;
 
         for artifact in artifacts {
             debug!("Running {:?}", artifact);

--- a/crates/cargo-acap-sdk/src/main.rs
+++ b/crates/cargo-acap-sdk/src/main.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-use std::{ffi::OsString, fs::File, str::FromStr};
+use std::{ffi::OsString, fs::File, path::PathBuf, str::FromStr};
 
 use acap_vapix::{applications_control, basic_device_info, HttpClient};
 use cargo_acap_build::Architecture;
@@ -72,6 +72,9 @@ enum Commands {
 // TODO: Include package selection for better completions and help messages.
 #[derive(clap::Args, Debug, Clone)]
 struct BuildOptions {
+    /// Path to Cargo.toml.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
     /// Pass additional arguments to `cargo build`.
     ///
     /// Beware that not all incompatible arguments have been documented.
@@ -80,7 +83,10 @@ struct BuildOptions {
 
 impl BuildOptions {
     async fn resolve(self, deploy_options: &DeployOptions) -> anyhow::Result<ResolvedBuildOptions> {
-        let Self { args } = self;
+        let Self {
+            manifest_path,
+            args,
+        } = self;
         // TODO: Consider using `get_properties` instead.
         let target = basic_device_info::Client::new(&deploy_options.http_client().await?)
             .get_all_properties()
@@ -90,7 +96,11 @@ impl BuildOptions {
             .restricted
             .architecture
             .parse()?;
-        Ok(ResolvedBuildOptions { target, args })
+        Ok(ResolvedBuildOptions {
+            target,
+            manifest_path,
+            args,
+        })
     }
 }
 
@@ -99,6 +109,9 @@ pub struct ResolvedBuildOptions {
     /// Architecture of the device to build for.
     #[arg(long, env = "AXIS_DEVICE_ARCH")]
     target: ArchAbi,
+    /// Path to Cargo.toml.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
     /// Pass additional arguments to `cargo build`.
     ///
     /// Beware that not all incompatible arguments have been documented.


### PR DESCRIPTION
Previously this could be passed to cargo after `--`, but doing so typically would not work since `cargo-acap-build` internally invokes Cargo to get the target dir. Now we explicitly parse that option and propagate it to all cargo subcommands.

I also considered leaving it after `--`, infer any manifest path from those args and propagate it explicitly only for the internal cargo sub- commands. I'm honestly unsure which is better.

Pros (of the current implementation):
- No fragile, ad-hoc parsing of arguments. There are many ways this could go wrong. We could forget to handle both "=" and " ", we could forget to handle "--" (any --manifest-path after such an argument would probably not go to cargo).
- It's clear to educated users which arguments directly affect the behavior of the `cargo-acap-*` programs.

Cons:
- The public interface of the programs change
- Our interface requires `--manifest-path` to come before the command while `cargo` expects it after the command.
