### PR TITLE
fix(vdo): compile against firmware-11 SDK 1.15.1 (VDO_ERROR_NO_VIDEO)

### DIFF
--- a/crates/vdo/src/lib.rs
+++ b/crates/vdo/src/lib.rs
@@ -145,7 +145,6 @@ impl VdoError {
             x if x == vdo_sys::VDO_ERROR_FATAL.0 as i32 => "VDO_ERROR_FATAL",
             x if x == vdo_sys::VDO_ERROR_NOT_CONTROLLED.0 as i32 => "VDO_ERROR_NOT_CONTROLLED",
             x if x == vdo_sys::VDO_ERROR_NO_EVENT.0 as i32 => "VDO_ERROR_NO_EVENT",
-            x if x == vdo_sys::VDO_ERROR_NO_VIDEO.0 as i32 => "VDO_ERROR_NO_VIDEO",
             _ => "VDO_ERROR_UNKNOWN",
         }
     }


### PR DESCRIPTION
Fixes #245.

`VdoError::code_name()` referenced `vdo_sys::VDO_ERROR_NO_VIDEO`, which the **firmware-11 Native SDK (`1.15.1`)** vdo headers don't define (it was added in a later SDK), so the `vdo` crate failed to build against that sysroot:

```
error[E0425]: cannot find value `VDO_ERROR_NO_VIDEO` in crate `vdo_sys`
   --> crates/vdo/src/lib.rs:148:32
```

The arm is diagnostic-only and the `_ => "VDO_ERROR_UNKNOWN"` catch-all already covers the code, so dropping it lets `vdo` compile against **both** the fw11 (`1.15.1`) and fw12 (`12.1.0`) SDK sysroots.

Verified end-to-end: with this change the crate cross-compiles under `axisecp/acap-native-sdk:1.15.1-{aarch64,armv7hf}-ubuntu22.04` and a real ACAP app (on-camera LL-HLS via VDO) runs on an ARTPEC-6 / firmware-11.11 camera.

If you'd rather **keep** the label for fw12+ instead of dropping it, a `cfg`/build-probe gate would also work — happy to switch this PR to that approach.
