### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/on-host-workflow.yml
+++ b/.github/workflows/on-host-workflow.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   debian_and_ubuntu:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/CI.yml`
- `.github/workflows/on-host-workflow.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.